### PR TITLE
fix: Handle HTTP redirects in workflow curl requests

### DIFF
--- a/.github/workflows/deploy-cloudflare.yml
+++ b/.github/workflows/deploy-cloudflare.yml
@@ -198,7 +198,7 @@ jobs:
           
           WORKER_URL="${CUSTOM_DOMAIN:-${{ steps.deploy.outputs.worker_url }}}"
 
-          HTTP_CODE=$(curl -sL -w "%{http_code}" -o response.txt \
+          HTTP_CODE=$(curl -sL --post301 --post302 --post303 -w "%{http_code}" -o response.txt \
             -X POST \
             -H "Content-Type: application/json" \
             -d "{\"domainList\": $DOMAIN,\"accountId\":\"$CLOUDFLARE_ACCOUNT_ID\",\"token\":\"$CLOUDFLARE_API_TOKEN\",\"workerName\":\"$NAME\"}" \


### PR DESCRIPTION
## Summary

Fix deployment workflow failures caused by HTTP redirects when `CUSTOM_DOMAIN` is configured without the `https://` protocol prefix.

## Problem

When users configure `CUSTOM_DOMAIN` without the protocol (e.g., `mail.example.com` instead of `https://mail.example.com`), the curl requests fail because:

1. **HTTP 301 redirects are not followed** - The server redirects HTTP → HTTPS, but curl doesn't follow redirects by default, resulting in:
   ```
   ❌ Failed. HTTP: 301, Response: 
   ```

2. **POST body is lost on redirect** - Even with `-L` (follow redirects), curl converts POST → GET when following 301/302 redirects, causing the JSON body to be discarded. This results in:
   ```json
   {"code": 500, "message": "Unexpected end of JSON input"}
   ```

## Solution

### Commit 1: Add `-L` flag to follow redirects (`d0800cf`)
- Added `-L` flag to both curl commands in the "Initialize database" and "Set up email receiving" steps
- This allows curl to automatically follow HTTP → HTTPS redirects

### Commit 2: Preserve POST method through redirects (`eebf38a`)
- Added `--post301 --post302 --post303` flags to the POST request in "Set up email receiving" step
- This ensures the POST method and request body are preserved when following redirects

## Changes

| File | Changes |
|------|---------|
| `.github/workflows/deploy-cloudflare.yml` | Modified curl commands to handle redirects properly |

## Testing

- Tested with `CUSTOM_DOMAIN` set without `https://` prefix
- Both "Initialize database" and "Set up email receiving" steps now complete successfully

## Recommendation

For best results, users should still configure `CUSTOM_DOMAIN` with the full URL including protocol:
```
https://mail.example.com
```
This avoids the redirect overhead entirely.
