### PR TITLE
Configure CORS allowlist via environment#1

### DIFF
--- a/mail-worker/src/hono/hono.js
+++ b/mail-worker/src/hono/hono.js
@@ -4,7 +4,63 @@ const app = new Hono();
 import result from '../model/result';
 import { cors } from 'hono/cors';
 
-app.use('*', cors());
+const normalizeOrigin = (origin) => {
+	if (!origin) {
+		return '';
+	}
+	return origin.trim().replace(/\/+$/, '');
+};
+
+const parseCorsOrigins = (env) => {
+	const rawOrigins = env?.cors_origins ?? env?.cors_origin ?? env?.cors_origins_json ?? env?.cors_origins_list;
+	if (!rawOrigins) {
+		return [];
+	}
+
+	if (Array.isArray(rawOrigins)) {
+		return rawOrigins.map(normalizeOrigin).filter(Boolean);
+	}
+
+	if (typeof rawOrigins === 'string') {
+		const trimmed = rawOrigins.trim();
+		if (!trimmed) {
+			return [];
+		}
+		if (trimmed.startsWith('[')) {
+			try {
+				const parsed = JSON.parse(trimmed);
+				if (Array.isArray(parsed)) {
+					return parsed.map(normalizeOrigin).filter(Boolean);
+				}
+			} catch (error) {
+				console.warn('Invalid cors_origins JSON, falling back to comma list', error);
+			}
+		}
+		return trimmed
+			.split(',')
+			.map((item) => normalizeOrigin(item))
+			.filter(Boolean);
+	}
+
+	return [];
+};
+
+app.use(
+	'*',
+	cors({
+		origin: (origin, c) => {
+			const allowList = parseCorsOrigins(c.env);
+			const normalized = normalizeOrigin(origin);
+			if (!normalized || allowList.length === 0) {
+				return undefined;
+			}
+			return allowList.includes(normalized) ? normalized : undefined;
+		},
+		credentials: false,
+		allowHeaders: ['Authorization', 'Content-Type'],
+		exposeHeaders: ['Content-Disposition']
+	})
+);
 
 app.onError((err, c) => {
 	if (err.name === 'BizError') {
@@ -29,5 +85,4 @@ app.onError((err, c) => {
 });
 
 export default app;
-
 

--- a/mail-worker/wrangler.toml
+++ b/mail-worker/wrangler.toml
@@ -34,6 +34,7 @@ crons = ["0 16 * * *"]	#定时任务每天晚上12点执行
 #domain = []				#邮件域名可可配置多个 示例: ["example1.com","example2.com"]
 #admin = ""				#管理员的邮箱	示例: admin@example.com
 #jwt_secret = ""			#jwt令牌的密钥,随便填一串字符串
+#cors_origins = []		#CORS允许的前端域名列表 示例: ["https://mail.example.com"]
 
 [build]
 command = "pnpm --prefix ../mail-vue install && pnpm --prefix ../mail-vue run build"


### PR DESCRIPTION
Motivation
Make CORS policy explicit and configurable so frontend origin changes can be updated from environment/wrangler config rather than hardcoded *.
Ensure sensible defaults for credentials, request/response headers and to reduce unsafe open CORS settings.
Description
Replace the global cors() call with an env-driven allowlist implementation in mail-worker/src/hono/hono.js that parses c.env values and normalizes origins via normalizeOrigin and parseCorsOrigins functions.
Configure the middleware origin callback to only return an allowed origin from env, and set credentials: false, allowHeaders: ['Authorization', 'Content-Type'], and exposeHeaders: ['Content-Disposition'] in the cors options.
Document a cors_origins example variable in mail-worker/wrangler.toml (commented) so deployers can supply allowed frontend domains (e.g. `[