### PR TITLE
fix: resolve 522 error when accessing root path after login

### DIFF
--- a/mail-worker/src/index.js
+++ b/mail-worker/src/index.js
@@ -16,6 +16,11 @@ export default {
 			return app.fetch(req, env, ctx);
 		}
 
+		// Handle root path explicitly to avoid potential issues with Cloudflare Workers Assets
+		if (url.pathname === '/' || url.pathname === '') {
+			return env.assets.fetch(new Request(new URL(req.url).origin + '/index.html', req));
+		}
+
 		 if (['/static/','/attachments/'].some(p => url.pathname.startsWith(p))) {
 			 return await kvObjService.toObjResp( { env }, url.pathname.substring(1));
 		 }


### PR DESCRIPTION
Fixes #279

## Summary
When accessing the root path `/` after login, Cloudflare Workers with `run_worker_first=true` may have issues serving the `index.html` properly through the Assets API, causing a 522 (Connection Timed Out) error.

This fix explicitly handles the root path by fetching `index.html` directly, ensuring consistent behavior between `/` and `/inbox` routes.

## Changes
- Added explicit handling for root path (`/` and empty string) in the worker fetch handler
- The fix fetches `/index.html` directly when accessing the root path

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*