### PR TITLE
feat: support internationalized domain names (IDN) and Unicode email addresses

### DIFF
--- a/mail-vue/src/utils/verify-utils.js
+++ b/mail-vue/src/utils/verify-utils.js
@@ -1,5 +1,5 @@
 export function isEmail(email) {
-    const reg = /^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~.-]+@([a-zA-Z0-9\p{L}\p{N}-]+\.)+[a-zA-Z\p{L}]{2,}$/u;
+    const reg = /^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~\p{L}\p{N}.-]+@([a-zA-Z0-9\p{L}\p{N}-]+\.)+[a-zA-Z\p{L}]{2,}$/u;
     return reg.test(email);
 }
 

--- a/mail-vue/src/utils/verify-utils.js
+++ b/mail-vue/src/utils/verify-utils.js
@@ -1,8 +1,8 @@
 export function isEmail(email) {
-    const reg = /^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~.-]+@([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/;
+    const reg = /^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~.-]+@([a-zA-Z0-9\p{L}\p{N}-]+\.)+[a-zA-Z\p{L}]{2,}$/u;
     return reg.test(email);
 }
 
 export function isDomain(str) {
-    return /^(?!:\/\/)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/.test(str);
+    return /^(?!:\/\/)([a-zA-Z0-9\p{L}\p{N}-]+\.)+[a-zA-Z\p{L}]{2,}$/u.test(str);
 }

--- a/mail-worker/src/email/email.js
+++ b/mail-worker/src/email/email.js
@@ -95,9 +95,9 @@ export async function email(message, env, ctx) {
 		const code = await aiService.extractCode({ env }, email, { aiCode, aiCodeFilter });
 
 		const params = {
-			toEmail: message.to,
+			toEmail: emailUtils.toPunycodeEmail(message.to),
 			toName: toName,
-			sendEmail: email.from.address,
+			sendEmail: emailUtils.toPunycodeEmail(email.from.address),
 			name: email.from.name || emailUtils.getName(email.from.address),
 			subject: email.subject,
 			code,
@@ -105,7 +105,7 @@ export async function email(message, env, ctx) {
 			text: email.text,
 			cc: email.cc ? JSON.stringify(email.cc) : '[]',
 			bcc: email.bcc ? JSON.stringify(email.bcc) : '[]',
-			recipient: JSON.stringify(email.to),
+			recipient: JSON.stringify(email.to.map(r => ({ ...r, address: emailUtils.toPunycodeEmail(r.address) }))),
 			inReplyTo: email.inReplyTo,
 			relation: email.references,
 			messageId: email.messageId,

--- a/mail-worker/src/email/email.js
+++ b/mail-worker/src/email/email.js
@@ -204,7 +204,7 @@ function checkBlock(blackSubjectStr, blackContentStr, blackFromStr, email) {
 	}
 
 	for (const blackFrom of blackFromList) {
-		if (email.from.address === blackFrom || emailUtils.getDomain(email.from.address) === blackFrom) {
+		if (email.from.address === blackFrom || emailUtils.getPunycodeDomain(email.from.address) === emailUtils.toPunycode(blackFrom)) {
 			return true
 		}
 	}

--- a/mail-worker/src/init/init.js
+++ b/mail-worker/src/init/init.js
@@ -29,6 +29,7 @@ const dbInit = {
 		await this.v2_8DB(c);
 		await this.v2_9DB(c);
 		await this.v3_0DB(c);
+		await this.v3_1DB(c);
 		await settingService.refresh(c);
 		return c.text('success');
 	},
@@ -54,6 +55,48 @@ const dbInit = {
 			console.warn(`跳过字段：${e.message}`);
 		}
 
+	},
+
+	async v3_1DB(c) {
+		try {
+			const { results: accounts } = await c.env.db.prepare('SELECT account_id, email FROM account').all();
+			for (const row of accounts) {
+				const punycodeEmail = emailUtils.toPunycodeEmail(row.email);
+				if (punycodeEmail !== row.email) {
+					await c.env.db.prepare('UPDATE account SET email = ? WHERE account_id = ?')
+						.bind(punycodeEmail, row.account_id).run();
+				}
+			}
+		} catch (e) {
+			console.warn(`跳过账号迁移：${e.message}`);
+		}
+
+		try {
+			const { results: users } = await c.env.db.prepare('SELECT user_id, email FROM user').all();
+			for (const row of users) {
+				const punycodeEmail = emailUtils.toPunycodeEmail(row.email);
+				if (punycodeEmail !== row.email) {
+					await c.env.db.prepare('UPDATE user SET email = ? WHERE user_id = ?')
+						.bind(punycodeEmail, row.user_id).run();
+				}
+			}
+		} catch (e) {
+			console.warn(`跳过用户迁移：${e.message}`);
+		}
+
+		try {
+			const { results: emails } = await c.env.db.prepare('SELECT email_id, send_email, to_email FROM email').all();
+			for (const row of emails) {
+				const punycodeSend = emailUtils.toPunycodeEmail(row.send_email);
+				const punycodeTo = emailUtils.toPunycodeEmail(row.to_email);
+				if (punycodeSend !== row.send_email || punycodeTo !== row.to_email) {
+					await c.env.db.prepare('UPDATE email SET send_email = ?, to_email = ? WHERE email_id = ?')
+						.bind(punycodeSend, punycodeTo, row.email_id).run();
+				}
+			}
+		} catch (e) {
+			console.warn(`跳过邮件迁移：${e.message}`);
+		}
 	},
 
 	async v2_9DB(c) {

--- a/mail-worker/src/model/result.js
+++ b/mail-worker/src/model/result.js
@@ -1,6 +1,9 @@
+import emailUtils from '../utils/email-utils';
+
 const result = {
 	ok(data) {
-		return { code: 200, message: 'success', data: data ? data : null };
+		const convertedData = emailUtils.convertEmailsToUnicode(data);
+		return { code: 200, message: 'success', data: convertedData ? convertedData : null };
 	},
 	fail(message, code = 500) {
 		return { code, message };

--- a/mail-worker/src/service/account-service.js
+++ b/mail-worker/src/service/account-service.js
@@ -35,7 +35,8 @@ const accountService = {
 			throw new BizError(t('notEmail'));
 		}
 
-		if (!c.env.domain.includes(emailUtils.getPunycodeDomain(email))) {
+		const punycodeDomains = c.env.domain.map(d => emailUtils.toPunycode(d));
+		if (!punycodeDomains.includes(emailUtils.getPunycodeDomain(email))) {
 			throw new BizError(t('notExistDomain'));
 		}
 

--- a/mail-worker/src/service/account-service.js
+++ b/mail-worker/src/service/account-service.js
@@ -89,7 +89,8 @@ const accountService = {
 		}
 
 
-		accountRow = await orm(c).insert(account).values({ email: email, userId: userId, name: emailUtils.getName(email) }).returning().get();
+		const punycodeEmail = emailUtils.toPunycodeEmail(email);
+		accountRow = await orm(c).insert(account).values({ email: punycodeEmail, userId: userId, name: emailUtils.getName(punycodeEmail) }).returning().get();
 
 		if (addEmailVerify === settingConst.addEmailVerify.COUNT && !addVerifyOpen) {
 			const row = await verifyRecordService.increaseAddCount(c);
@@ -101,7 +102,8 @@ const accountService = {
 	},
 
 	selectByEmailIncludeDel(c, email) {
-		return orm(c).select().from(account).where(sql`${account.email} COLLATE NOCASE = ${email}`).get();
+		const punycodeEmail = emailUtils.toPunycodeEmail(email);
+		return orm(c).select().from(account).where(sql`${account.email} COLLATE NOCASE = ${punycodeEmail}`).get();
 	},
 
 	list(c, params, userId) {

--- a/mail-worker/src/service/account-service.js
+++ b/mail-worker/src/service/account-service.js
@@ -103,7 +103,14 @@ const accountService = {
 
 	selectByEmailIncludeDel(c, email) {
 		const punycodeEmail = emailUtils.toPunycodeEmail(email);
-		return orm(c).select().from(account).where(sql`${account.email} COLLATE NOCASE = ${punycodeEmail}`).get();
+		let result = orm(c).select().from(account).where(sql`${account.email} COLLATE NOCASE = ${punycodeEmail}`).get();
+		if (!result) {
+			const unicodeEmail = emailUtils.fromPunycodeEmail(email);
+			if (unicodeEmail !== punycodeEmail) {
+				result = orm(c).select().from(account).where(sql`${account.email} COLLATE NOCASE = ${unicodeEmail}`).get();
+			}
+		}
+		return result;
 	},
 
 	list(c, params, userId) {

--- a/mail-worker/src/service/account-service.js
+++ b/mail-worker/src/service/account-service.js
@@ -35,7 +35,7 @@ const accountService = {
 			throw new BizError(t('notEmail'));
 		}
 
-		if (!c.env.domain.includes(emailUtils.getDomain(email))) {
+		if (!c.env.domain.includes(emailUtils.getPunycodeDomain(email))) {
 			throw new BizError(t('notExistDomain'));
 		}
 

--- a/mail-worker/src/service/account-service.js
+++ b/mail-worker/src/service/account-service.js
@@ -103,14 +103,7 @@ const accountService = {
 
 	selectByEmailIncludeDel(c, email) {
 		const punycodeEmail = emailUtils.toPunycodeEmail(email);
-		let result = orm(c).select().from(account).where(sql`${account.email} COLLATE NOCASE = ${punycodeEmail}`).get();
-		if (!result) {
-			const unicodeEmail = emailUtils.fromPunycodeEmail(email);
-			if (unicodeEmail !== punycodeEmail) {
-				result = orm(c).select().from(account).where(sql`${account.email} COLLATE NOCASE = ${unicodeEmail}`).get();
-			}
-		}
-		return result;
+		return orm(c).select().from(account).where(sql`${account.email} COLLATE NOCASE = ${punycodeEmail}`).get();
 	},
 
 	list(c, params, userId) {

--- a/mail-worker/src/service/ai-service.js
+++ b/mail-worker/src/service/ai-service.js
@@ -63,9 +63,12 @@ const aiService = {
 		}
 
 		const fromEmail = (email.from?.address || '').trim().toLowerCase();
-		const fromDomain = emailUtils.getDomain(fromEmail).toLowerCase();
+		const fromDomain = emailUtils.getPunycodeDomain(fromEmail).toLowerCase();
 
-		return filterList.some(item => item === fromEmail || item === fromDomain);
+		return filterList.some(item => {
+			const itemLower = item.toLowerCase();
+			return itemLower === fromEmail || emailUtils.toPunycode(itemLower) === fromDomain;
+		});
 	}
 };
 

--- a/mail-worker/src/service/email-service.js
+++ b/mail-worker/src/service/email-service.js
@@ -164,6 +164,8 @@ const emailService = {
 			attachments = [] //附件
 		} = params;
 
+		receiveEmail = receiveEmail.map(e => emailUtils.toPunycodeEmail(e));
+
 		const { resendTokens, r2Domain, send, punycodeDomainList } = await settingService.query(c);
 
 		let { imageDataList, html } = await attService.toImageUrlHtml(c, content);

--- a/mail-worker/src/service/email-service.js
+++ b/mail-worker/src/service/email-service.js
@@ -164,7 +164,7 @@ const emailService = {
 			attachments = [] //附件
 		} = params;
 
-		const { resendTokens, r2Domain, send, domainList } = await settingService.query(c);
+		const { resendTokens, r2Domain, send, punycodeDomainList } = await settingService.query(c);
 
 		let { imageDataList, html } = await attService.toImageUrlHtml(c, content);
 
@@ -179,7 +179,7 @@ const emailService = {
 		//判断接收方是不是全部为站内邮箱
 		const allInternal = receiveEmail.every(email => {
 			const domain = '@' + emailUtils.getPunycodeDomain(email);
-			return domainList.includes(domain);
+			return punycodeDomainList.includes(domain);
 		});
 
 		if (c.env.admin !== userRow.email) {

--- a/mail-worker/src/service/email-service.js
+++ b/mail-worker/src/service/email-service.js
@@ -179,7 +179,7 @@ const emailService = {
 		//判断接收方是不是全部为站内邮箱
 		const allInternal = receiveEmail.every(email => {
 			const domain = '@' + emailUtils.getPunycodeDomain(email);
-			return domainList.some(d => emailUtils.toPunycode(d.slice(1)) === domain);
+			return domainList.includes(domain);
 		});
 
 		if (c.env.admin !== userRow.email) {

--- a/mail-worker/src/service/email-service.js
+++ b/mail-worker/src/service/email-service.js
@@ -178,8 +178,8 @@ const emailService = {
 
 		//判断接收方是不是全部为站内邮箱
 		const allInternal = receiveEmail.every(email => {
-			const domain = '@' + emailUtils.getDomain(email);
-			return domainList.includes(domain);
+			const domain = '@' + emailUtils.getPunycodeDomain(email);
+			return domainList.some(d => emailUtils.toPunycode(d.slice(1)) === domain);
 		});
 
 		if (c.env.admin !== userRow.email) {
@@ -229,7 +229,7 @@ const emailService = {
 
 		}
 
-		const domain = emailUtils.getDomain(accountRow.email);
+		const domain = emailUtils.getPunycodeDomain(accountRow.email);
 		const resendToken = resendTokens[domain];
 		const useCloudflareEmail = !!c.env.email;
 
@@ -377,8 +377,8 @@ const emailService = {
 
 	async sendByCloudflareEmail(c, params) {
 		const sendForm = {
-			from: { email: params.accountEmail, name: params.name },
-			to: [...params.receiveEmail],
+			from: { email: emailUtils.toPunycodeEmail(params.accountEmail), name: params.name },
+			to: params.receiveEmail.map(e => emailUtils.toPunycodeEmail(e)),
 			subject: params.subject
 		};
 
@@ -417,8 +417,8 @@ const emailService = {
 		const resend = new Resend(resendToken);
 
 		const sendForm = {
-			from: `${params.name} <${params.accountEmail}>`,
-			to: [...params.receiveEmail],
+			from: `${params.name} <${emailUtils.toPunycodeEmail(params.accountEmail)}>`,
+			to: params.receiveEmail.map(e => emailUtils.toPunycodeEmail(e)),
 			subject: params.subject,
 			text: params.text,
 			html: params.html,

--- a/mail-worker/src/service/email-service.js
+++ b/mail-worker/src/service/email-service.js
@@ -549,18 +549,8 @@ const emailService = {
 
 		const { noRecipient  } = await settingService.query(c);
 
-		//兼容数据库中文和 punycode 两种邮箱格式
-		const searchEmails = [];
-		for (const email of receiveEmail) {
-			searchEmails.push(email);
-			const unicodeEmail = emailUtils.fromPunycodeEmail(email);
-			if (unicodeEmail !== email) {
-				searchEmails.push(unicodeEmail);
-			}
-		}
-
 		//查询所有收件人账号信息
-		let accountList = await orm(c).select().from(account).where(inArray(account.email, searchEmails)).all();
+		let accountList = await orm(c).select().from(account).where(inArray(account.email, receiveEmail)).all();
 
 		//查询所有收件人权限身份
 		const userIds = accountList.map(accountRow => accountRow.userId);
@@ -579,8 +569,7 @@ const emailService = {
 			emailValues.toName = emailUtils.getName(email);
 			emailValues.emailId = null;
 
-			const accountRow = accountList.find(accountRow =>
-				accountRow.email === email || emailUtils.toPunycodeEmail(accountRow.email) === email);
+			const accountRow = accountList.find(accountRow => accountRow.email === email);
 
 			//如果收件人存在就把邮件信息改成收件人的
 			if (accountRow) {

--- a/mail-worker/src/service/email-service.js
+++ b/mail-worker/src/service/email-service.js
@@ -549,8 +549,18 @@ const emailService = {
 
 		const { noRecipient  } = await settingService.query(c);
 
+		//兼容数据库中文和 punycode 两种邮箱格式
+		const searchEmails = [];
+		for (const email of receiveEmail) {
+			searchEmails.push(email);
+			const unicodeEmail = emailUtils.fromPunycodeEmail(email);
+			if (unicodeEmail !== email) {
+				searchEmails.push(unicodeEmail);
+			}
+		}
+
 		//查询所有收件人账号信息
-		let accountList = await orm(c).select().from(account).where(inArray(account.email, receiveEmail)).all();
+		let accountList = await orm(c).select().from(account).where(inArray(account.email, searchEmails)).all();
 
 		//查询所有收件人权限身份
 		const userIds = accountList.map(accountRow => accountRow.userId);
@@ -569,7 +579,8 @@ const emailService = {
 			emailValues.toName = emailUtils.getName(email);
 			emailValues.emailId = null;
 
-			const accountRow = accountList.find(accountRow => accountRow.email === email);
+			const accountRow = accountList.find(accountRow =>
+				accountRow.email === email || emailUtils.toPunycodeEmail(accountRow.email) === email);
 
 			//如果收件人存在就把邮件信息改成收件人的
 			if (accountRow) {

--- a/mail-worker/src/service/login-service.js
+++ b/mail-worker/src/service/login-service.js
@@ -61,7 +61,8 @@ const loginService = {
 			throw new BizError(t('pwdMinLength'));
 		}
 
-		if (!c.env.domain.includes(emailUtils.getPunycodeDomain(email))) {
+		const punycodeDomains = c.env.domain.map(d => emailUtils.toPunycode(d));
+		if (!punycodeDomains.includes(emailUtils.getPunycodeDomain(email))) {
 			throw new BizError(t('notEmailDomain'));
 		}
 

--- a/mail-worker/src/service/login-service.js
+++ b/mail-worker/src/service/login-service.js
@@ -129,9 +129,10 @@ const loginService = {
 
 		const { salt, hash } = await saltHashUtils.hashPassword(password);
 
-		const userId = await userService.insert(c, { email, regKeyId,password: hash, salt, type: type || defType });
+		const punycodeEmail = emailUtils.toPunycodeEmail(email);
+		const userId = await userService.insert(c, { email: punycodeEmail, regKeyId, password: hash, salt, type: type || defType });
 
-		await accountService.insert(c, { userId: userId, email, name: emailUtils.getName(email) });
+		await accountService.insert(c, { userId: userId, email: punycodeEmail, name: emailUtils.getName(punycodeEmail) });
 
 		await userService.updateUserInfo(c, userId, true);
 

--- a/mail-worker/src/service/login-service.js
+++ b/mail-worker/src/service/login-service.js
@@ -61,7 +61,7 @@ const loginService = {
 			throw new BizError(t('pwdMinLength'));
 		}
 
-		if (!c.env.domain.includes(emailUtils.getDomain(email))) {
+		if (!c.env.domain.includes(emailUtils.getPunycodeDomain(email))) {
 			throw new BizError(t('notEmailDomain'));
 		}
 

--- a/mail-worker/src/service/public-service.js
+++ b/mail-worker/src/service/public-service.js
@@ -129,6 +129,7 @@ const publicService = {
 
 		for (const emailRow of list) {
 			let { email, hash, salt, roleName } = emailRow;
+			email = emailUtils.toPunycodeEmail(email);
 			let type = defRole.roleId;
 
 			if (roleName) {

--- a/mail-worker/src/service/public-service.js
+++ b/mail-worker/src/service/public-service.js
@@ -104,7 +104,8 @@ const publicService = {
 				throw new BizError(t('notEmail'));
 			}
 
-			if (!c.env.domain.includes(emailUtils.getPunycodeDomain(emailRow.email))) {
+			const punycodeDomains = c.env.domain.map(d => emailUtils.toPunycode(d));
+			if (!punycodeDomains.includes(emailUtils.getPunycodeDomain(emailRow.email))) {
 				throw new BizError(t('notEmailDomain'));
 			}
 

--- a/mail-worker/src/service/public-service.js
+++ b/mail-worker/src/service/public-service.js
@@ -104,7 +104,7 @@ const publicService = {
 				throw new BizError(t('notEmail'));
 			}
 
-			if (!c.env.domain.includes(emailUtils.getDomain(emailRow.email))) {
+			if (!c.env.domain.includes(emailUtils.getPunycodeDomain(emailRow.email))) {
 				throw new BizError(t('notEmailDomain'));
 			}
 

--- a/mail-worker/src/service/role-service.js
+++ b/mail-worker/src/service/role-service.js
@@ -163,8 +163,8 @@ const roleService = {
 		}
 
 		const availIndex = availDomain.findIndex(item => {
-			const domain = emailUtils.getDomain(email.toLowerCase());
-			const availDomainItem = item.toLowerCase();
+			const domain = emailUtils.getPunycodeDomain(email.toLowerCase());
+			const availDomainItem = emailUtils.toPunycode(item.toLowerCase());
 			return domain === availDomainItem
 		})
 
@@ -197,8 +197,8 @@ const roleService = {
 
 			if (verifyUtils.isDomain(item)) {
 
-				const banDomain = item.toLowerCase();
-				const receiveDomain = emailUtils.getDomain(fromEmail.toLowerCase());
+				const banDomain = emailUtils.toPunycode(item.toLowerCase());
+				const receiveDomain = emailUtils.getPunycodeDomain(fromEmail.toLowerCase());
 
 				if (banDomain === receiveDomain) {
 					return true;

--- a/mail-worker/src/service/setting-service.js
+++ b/mail-worker/src/service/setting-service.js
@@ -45,7 +45,7 @@ const settingService = {
 			throw new BizError(t('noDomainVariable'));
 		}
 
-		domainList = domainList.map(item => '@' + item);
+		domainList = domainList.map(item => '@' + emailUtils.toPunycode(item));
 		setting.domainList = domainList;
 
 
@@ -126,9 +126,13 @@ const settingService = {
 	async set(c, params) {
 		const settingData = await this.query(c);
 		let resendTokens = { ...settingData.resendTokens, ...params.resendTokens };
+		const punycodeTokens = {};
 		Object.keys(resendTokens).forEach(domain => {
-			if (!resendTokens[domain]) delete resendTokens[domain];
+			if (resendTokens[domain]) {
+				punycodeTokens[emailUtils.toPunycode(domain)] = resendTokens[domain];
+			}
 		});
+		resendTokens = punycodeTokens;
 
 		if (Array.isArray(params.emailPrefixFilter)) {
 			params.emailPrefixFilter = params.emailPrefixFilter + '';

--- a/mail-worker/src/service/setting-service.js
+++ b/mail-worker/src/service/setting-service.js
@@ -46,7 +46,8 @@ const settingService = {
 			throw new BizError(t('noDomainVariable'));
 		}
 
-		domainList = domainList.map(item => '@' + emailUtils.toPunycode(item));
+		setting.punycodeDomainList = domainList.map(item => '@' + emailUtils.toPunycode(item));
+		domainList = domainList.map(item => '@' + item);
 		setting.domainList = domainList;
 
 

--- a/mail-worker/src/service/setting-service.js
+++ b/mail-worker/src/service/setting-service.js
@@ -9,6 +9,7 @@ import BizError from '../error/biz-error';
 import {t} from '../i18n/i18n'
 import verifyRecordService from './verify-record-service';
 import userContext from '../security/user-context';
+import emailUtils from '../utils/email-utils';
 
 const settingService = {
 

--- a/mail-worker/src/service/user-service.js
+++ b/mail-worker/src/service/user-service.js
@@ -306,7 +306,8 @@ const userService = {
 
 		const { email, type, password } = params;
 
-		if (!c.env.domain.includes(emailUtils.getPunycodeDomain(email))) {
+		const punycodeDomains = c.env.domain.map(d => emailUtils.toPunycode(d));
+		if (!punycodeDomains.includes(emailUtils.getPunycodeDomain(email))) {
 			throw new BizError(t('notEmailDomain'));
 		}
 

--- a/mail-worker/src/service/user-service.js
+++ b/mail-worker/src/service/user-service.js
@@ -66,9 +66,10 @@ const userService = {
 	},
 
 	selectByEmail(c, email) {
+		const punycodeEmail = emailUtils.toPunycodeEmail(email);
 		return orm(c).select().from(user).where(
 			and(
-				eq(user.email, email),
+				eq(user.email, punycodeEmail),
 				eq(user.isDel, isDel.NORMAL)))
 			.get();
 	},
@@ -79,7 +80,8 @@ const userService = {
 	},
 
 	selectByEmailIncludeDel(c, email) {
-		return orm(c).select().from(user).where(sql`${user.email} COLLATE NOCASE = ${email}`).get();
+		const punycodeEmail = emailUtils.toPunycodeEmail(email);
+		return orm(c).select().from(user).where(sql`${user.email} COLLATE NOCASE = ${punycodeEmail}`).get();
 	},
 
 	selectByIdIncludeDel(c, userId) {
@@ -333,11 +335,12 @@ const userService = {
 
 		const { salt, hash } = await saltHashUtils.hashPassword(password);
 
-		const userId = await userService.insert(c, { email, password: hash, salt, type });
+		const punycodeEmail = emailUtils.toPunycodeEmail(email);
+		const userId = await userService.insert(c, { email: punycodeEmail, password: hash, salt, type });
 
 		await userService.updateUserInfo(c, userId, true);
 
-		await accountService.insert(c, { userId: userId, email, type, name: emailUtils.getName(email) });
+		await accountService.insert(c, { userId: userId, email: punycodeEmail, type, name: emailUtils.getName(punycodeEmail) });
 	},
 
 	async resetDaySendCount(c) {

--- a/mail-worker/src/service/user-service.js
+++ b/mail-worker/src/service/user-service.js
@@ -67,11 +67,22 @@ const userService = {
 
 	selectByEmail(c, email) {
 		const punycodeEmail = emailUtils.toPunycodeEmail(email);
-		return orm(c).select().from(user).where(
+		let result = orm(c).select().from(user).where(
 			and(
 				eq(user.email, punycodeEmail),
 				eq(user.isDel, isDel.NORMAL)))
 			.get();
+		if (!result) {
+			const unicodeEmail = emailUtils.fromPunycodeEmail(email);
+			if (unicodeEmail !== punycodeEmail) {
+				result = orm(c).select().from(user).where(
+					and(
+						eq(user.email, unicodeEmail),
+						eq(user.isDel, isDel.NORMAL)))
+					.get();
+			}
+		}
+		return result;
 	},
 
 	async insert(c, params) {
@@ -81,7 +92,14 @@ const userService = {
 
 	selectByEmailIncludeDel(c, email) {
 		const punycodeEmail = emailUtils.toPunycodeEmail(email);
-		return orm(c).select().from(user).where(sql`${user.email} COLLATE NOCASE = ${punycodeEmail}`).get();
+		let result = orm(c).select().from(user).where(sql`${user.email} COLLATE NOCASE = ${punycodeEmail}`).get();
+		if (!result) {
+			const unicodeEmail = emailUtils.fromPunycodeEmail(email);
+			if (unicodeEmail !== punycodeEmail) {
+				result = orm(c).select().from(user).where(sql`${user.email} COLLATE NOCASE = ${unicodeEmail}`).get();
+			}
+		}
+		return result;
 	},
 
 	selectByIdIncludeDel(c, userId) {

--- a/mail-worker/src/service/user-service.js
+++ b/mail-worker/src/service/user-service.js
@@ -67,22 +67,11 @@ const userService = {
 
 	selectByEmail(c, email) {
 		const punycodeEmail = emailUtils.toPunycodeEmail(email);
-		let result = orm(c).select().from(user).where(
+		return orm(c).select().from(user).where(
 			and(
 				eq(user.email, punycodeEmail),
 				eq(user.isDel, isDel.NORMAL)))
 			.get();
-		if (!result) {
-			const unicodeEmail = emailUtils.fromPunycodeEmail(email);
-			if (unicodeEmail !== punycodeEmail) {
-				result = orm(c).select().from(user).where(
-					and(
-						eq(user.email, unicodeEmail),
-						eq(user.isDel, isDel.NORMAL)))
-					.get();
-			}
-		}
-		return result;
 	},
 
 	async insert(c, params) {
@@ -92,14 +81,7 @@ const userService = {
 
 	selectByEmailIncludeDel(c, email) {
 		const punycodeEmail = emailUtils.toPunycodeEmail(email);
-		let result = orm(c).select().from(user).where(sql`${user.email} COLLATE NOCASE = ${punycodeEmail}`).get();
-		if (!result) {
-			const unicodeEmail = emailUtils.fromPunycodeEmail(email);
-			if (unicodeEmail !== punycodeEmail) {
-				result = orm(c).select().from(user).where(sql`${user.email} COLLATE NOCASE = ${unicodeEmail}`).get();
-			}
-		}
-		return result;
+		return orm(c).select().from(user).where(sql`${user.email} COLLATE NOCASE = ${punycodeEmail}`).get();
 	},
 
 	selectByIdIncludeDel(c, userId) {

--- a/mail-worker/src/service/user-service.js
+++ b/mail-worker/src/service/user-service.js
@@ -306,7 +306,7 @@ const userService = {
 
 		const { email, type, password } = params;
 
-		if (!c.env.domain.includes(emailUtils.getDomain(email))) {
+		if (!c.env.domain.includes(emailUtils.getPunycodeDomain(email))) {
 			throw new BizError(t('notEmailDomain'));
 		}
 

--- a/mail-worker/src/utils/email-utils.js
+++ b/mail-worker/src/utils/email-utils.js
@@ -1,4 +1,5 @@
 import { parseHTML } from 'linkedom';
+import { domainToUnicode } from 'node:url';
 
 const emailUtils = {
 
@@ -63,6 +64,49 @@ const emailUtils = {
 		const parts = email.split('@');
 		if (parts.length !== 2) return email;
 		return parts[0] + '@' + this.toPunycode(parts[1]);
+	},
+
+	fromPunycode(domain) {
+		if (typeof domain !== 'string') return '';
+		if (!domain.includes('xn--')) return domain;
+		try {
+			return domainToUnicode(domain);
+		} catch {
+			return domain;
+		}
+	},
+
+	fromPunycodeEmail(email) {
+		if (typeof email !== 'string') return '';
+		const parts = email.split('@');
+		if (parts.length !== 2) return email;
+		return parts[0] + '@' + this.fromPunycode(parts[1]);
+	},
+
+	convertEmailsToUnicode(data) {
+		if (Array.isArray(data)) {
+			return data.map(item => this.convertEmailsToUnicode(item));
+		}
+		if (data && typeof data === 'object') {
+			const result = {};
+			for (const key of Object.keys(data)) {
+				const value = data[key];
+				if (['email', 'sendEmail', 'toEmail', 'userEmail', 'send_email', 'to_email', 'from', 'to', 'address'].includes(key) && typeof value === 'string' && value.includes('@')) {
+					result[key] = this.fromPunycodeEmail(value);
+				} else if (key === 'recipient' && typeof value === 'string') {
+					try {
+						const parsed = JSON.parse(value);
+						result[key] = JSON.stringify(this.convertEmailsToUnicode(parsed));
+					} catch {
+						result[key] = value;
+					}
+				} else {
+					result[key] = this.convertEmailsToUnicode(value);
+				}
+			}
+			return result;
+		}
+		return data;
 	}
 };
 

--- a/mail-worker/src/utils/email-utils.js
+++ b/mail-worker/src/utils/email-utils.js
@@ -116,7 +116,7 @@ const emailUtils = {
 		if (typeof email !== 'string') return '';
 		const parts = email.split('@');
 		if (parts.length !== 2) return email;
-		return parts[0] + '@' + this.toPunycode(parts[1]);
+		return this.toPunycode(parts[0]) + '@' + this.toPunycode(parts[1]);
 	},
 
 	fromPunycode(domain) {

--- a/mail-worker/src/utils/email-utils.js
+++ b/mail-worker/src/utils/email-utils.js
@@ -1,5 +1,58 @@
 import { parseHTML } from 'linkedom';
-import { domainToUnicode } from 'node:url';
+
+function decodePunycodeLabel(encoded) {
+	const base = 36, tmin = 1, tmax = 26, skew = 38, damp = 700, initialBias = 72, initialN = 128;
+
+	function decodeDigit(cp) {
+		const n = cp.charCodeAt(0);
+		if (n >= 0x41 && n <= 0x5A) return n - 0x41;
+		if (n >= 0x61 && n <= 0x7A) return n - 0x61;
+		if (n >= 0x30 && n <= 0x39) return n - 0x30 + 26;
+		throw new Error('Invalid punycode digit');
+	}
+
+	function adapt(delta, numPoints, firstTime) {
+		delta = firstTime ? Math.floor(delta / damp) : Math.floor(delta / 2);
+		delta += Math.floor(delta / numPoints);
+		let k = 0;
+		while (delta > Math.floor(((base - tmin) * tmax) / 2)) {
+			delta = Math.floor(delta / (base - tmin));
+			k += base;
+		}
+		return k + Math.floor((((base - tmin + 1) * delta) / (delta + skew)));
+	}
+
+	const delimIndex = encoded.lastIndexOf('-');
+	let output = [];
+	if (delimIndex >= 0) {
+		output = encoded.slice(0, delimIndex).split('').map(c => c.charCodeAt(0));
+		encoded = encoded.slice(delimIndex + 1);
+	}
+
+	let i = 0, n = initialN, bias = initialBias;
+
+	while (encoded.length > 0) {
+		const prevI = i;
+		let w = 1;
+		for (let k = base; ; k += base) {
+			const digit = decodeDigit(encoded[0]);
+			encoded = encoded.slice(1);
+			i += digit * w;
+			const t = k <= bias ? tmin : k >= bias + tmax ? tmax : k - bias;
+			if (digit < t) break;
+			w *= base - t;
+		}
+
+		const outLen = output.length + 1;
+		bias = adapt(i - prevI, outLen, prevI === 0);
+		n += Math.floor(i / outLen);
+		i %= outLen;
+		output.splice(i, 0, n);
+		i++;
+	}
+
+	return String.fromCharCode(...output);
+}
 
 const emailUtils = {
 
@@ -70,7 +123,13 @@ const emailUtils = {
 		if (typeof domain !== 'string') return '';
 		if (!domain.includes('xn--')) return domain;
 		try {
-			return domainToUnicode(domain);
+			const parts = domain.split('.');
+			return parts.map(part => {
+				if (part.startsWith('xn--')) {
+					return decodePunycodeLabel(part.slice(4));
+				}
+				return part;
+			}).join('.');
 		} catch {
 			return domain;
 		}

--- a/mail-worker/src/utils/email-utils.js
+++ b/mail-worker/src/utils/email-utils.js
@@ -42,6 +42,27 @@ const emailUtils = {
 			console.error(e)
 			return ''
 		}
+	},
+
+	toPunycode(domain) {
+		if (typeof domain !== 'string') return '';
+		try {
+			return new URL('http://' + domain).hostname;
+		} catch {
+			return domain;
+		}
+	},
+
+	getPunycodeDomain(email) {
+		const domain = this.getDomain(email);
+		return this.toPunycode(domain);
+	},
+
+	toPunycodeEmail(email) {
+		if (typeof email !== 'string') return '';
+		const parts = email.split('@');
+		if (parts.length !== 2) return email;
+		return parts[0] + '@' + this.toPunycode(parts[1]);
 	}
 };
 

--- a/mail-worker/src/utils/email-utils.js
+++ b/mail-worker/src/utils/email-utils.js
@@ -139,7 +139,7 @@ const emailUtils = {
 		if (typeof email !== 'string') return '';
 		const parts = email.split('@');
 		if (parts.length !== 2) return email;
-		return parts[0] + '@' + this.fromPunycode(parts[1]);
+		return this.fromPunycode(parts[0]) + '@' + this.fromPunycode(parts[1]);
 	},
 
 	convertEmailsToUnicode(data) {

--- a/mail-worker/src/utils/verify-utils.js
+++ b/mail-worker/src/utils/verify-utils.js
@@ -1,9 +1,9 @@
 const verifyUtils = {
 	isEmail(str) {
-		return  /^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~.-]+@([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/.test(str);
+		return  /^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~.-]+@([a-zA-Z0-9\p{L}\p{N}-]+\.)+[a-zA-Z\p{L}]{2,}$/u.test(str);
 	},
 	isDomain(str) {
-		return /^(?!:\/\/)([a-zA-Z0-9-]+\.)+[a-zA-Z]{2,}$/.test(str);
+		return /^(?!:\/\/)([a-zA-Z0-9\p{L}\p{N}-]+\.)+[a-zA-Z\p{L}]{2,}$/u.test(str);
 	}
 }
 

--- a/mail-worker/src/utils/verify-utils.js
+++ b/mail-worker/src/utils/verify-utils.js
@@ -1,6 +1,6 @@
 const verifyUtils = {
 	isEmail(str) {
-		return  /^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~.-]+@([a-zA-Z0-9\p{L}\p{N}-]+\.)+[a-zA-Z\p{L}]{2,}$/u.test(str);
+		return  /^[a-zA-Z0-9!#$%&'*+/=?^_`{|}~\p{L}\p{N}.-]+@([a-zA-Z0-9\p{L}\p{N}-]+\.)+[a-zA-Z\p{L}]{2,}$/u.test(str);
 	},
 	isDomain(str) {
 		return /^(?!:\/\/)([a-zA-Z0-9\p{L}\p{N}-]+\.)+[a-zA-Z\p{L}]{2,}$/u.test(str);


### PR DESCRIPTION
## Summary
- Support Chinese domain names (e.g. `用户@例子.中国`) and Unicode local-parts (e.g. `测试@公司.com`)
- Store all emails as punycode in database, transparently converting to/from Unicode for the frontend
- Resend and Cloudflare Email APIs receive pure ASCII punycode addresses

## How it works

用户输入:  测试@公司.com
↓ toPunycodeEmail()
数据库存储:  [xn--0zwm56d@xn--55qx5d.com](mailto:xn--0zwm56d@xn--55qx5d.com)
外部API:    [xn--0zwm56d@xn--55qx5d.com](mailto:xn--0zwm56d@xn--55qx5d.com)  (纯ASCII)
↓ fromPunycodeEmail()
前端显示:  测试@公司.com



## Changes

### Email validation (`verify-utils.js` ×2)
- Regex now allows `\p{L}` Unicode letters in both local-part and domain

### Punycode engine (`email-utils.js`)
- `toPunycode(domain)` — encode via `URL.hostname`
- `fromPunycode(domain)` — decode via pure JS RFC 3492 decoder
- `toPunycodeEmail(email)` — encode both local-part and domain
- `fromPunycodeEmail(email)` — decode both local-part and domain

### Backend storage
- All new accounts/users/emails stored with punycode addresses
- `init.js` v3.1 migration for existing Chinese data

### Domain comparison
- `c.env.domain` normalized to punycode before all `includes()` checks
- `resendTokens` keys normalized to punycode
- `setting.punycodeDomainList` for backend, `setting.domainList` (native) for UI

### Frontend display
- `result.ok()` auto-converts email fields via `convertEmailsToUnicode()`
- Frontend receives Chinese addresses without code changes

### Files changed (15 files, +236 / -37)
`mail-vue/`: verify-utils.js
`mail-worker/src/`: email-utils.js, verify-utils.js, result.js, init.js
`mail-worker/src/service/`: account, user, login, public, email, role, ai, setting
`mail-worker/src/email/`: email.js

## Test plan
- [x] Register with Chinese domain
- [x] Send via Resend — no non-ASCII errors
- [x] Receive to Chinese address — correctly mapped to inbox
- [x] Frontend displays decoded Chinese addresses
- [x] Existing ASCII accounts unaffected
