### PR TITLE
feat(security): rate limiting, input sanitization, security headers & per-user forwarding

### DIFF
--- a/mail-worker/src/api/account-api.js
+++ b/mail-worker/src/api/account-api.js
@@ -32,3 +32,8 @@ app.put('/account/setAsTop', async (c) => {
 	await accountService.setAsTop(c, await c.req.json(), userContext.getUserId(c));
 	return c.json(result.ok());
 });
+
+app.put('/account/setForward', async (c) => {
+	await accountService.setForward(c, await c.req.json(), userContext.getUserId(c));
+	return c.json(result.ok());
+});

--- a/mail-worker/src/api/login-api.js
+++ b/mail-worker/src/api/login-api.js
@@ -2,14 +2,26 @@ import app from '../hono/hono';
 import loginService from '../service/login-service';
 import result from '../model/result';
 import userContext from '../security/user-context';
+import rateLimiter from '../utils/rate-limiter';
+import sanitizeUtils from '../utils/sanitize-utils';
 
 app.post('/login', async (c) => {
-	const token = await loginService.login(c, await c.req.json());
+	const ip = rateLimiter.getClientIp(c);
+	if (await rateLimiter.isLimited(c.env, `login:${ip}`, 5, 60)) {
+		return c.json(result.fail('Too many login attempts, please try again later', 429), 429);
+	}
+	const params = sanitizeUtils.sanitizeParams(await c.req.json());
+	const token = await loginService.login(c, params);
 	return c.json(result.ok({ token: token }));
 });
 
 app.post('/register', async (c) => {
-	const jwt = await loginService.register(c, await c.req.json());
+	const ip = rateLimiter.getClientIp(c);
+	if (await rateLimiter.isLimited(c.env, `register:${ip}`, 3, 300)) {
+		return c.json(result.fail('Too many registration attempts, please try again later', 429), 429);
+	}
+	const params = sanitizeUtils.sanitizeParams(await c.req.json());
+	const jwt = await loginService.register(c, params);
 	return c.json(result.ok(jwt));
 });
 

--- a/mail-worker/src/email/email.js
+++ b/mail-worker/src/email/email.js
@@ -179,6 +179,15 @@ export async function email(message, env, ctx) {
 
 		}
 
+		// Per-user forwarding (account-level)
+		if (account && account.forwardEmail) {
+			try {
+				await message.forward(account.forwardEmail);
+			} catch (e) {
+				console.error(`Per-user forward to ${account.forwardEmail} failed:`, e);
+			}
+		}
+
 	} catch (e) {
 		console.error('邮件接收异常: ', e);
 		throw e

--- a/mail-worker/src/entity/account.js
+++ b/mail-worker/src/entity/account.js
@@ -11,5 +11,6 @@ export const account = sqliteTable('account', {
 	allReceive: integer('all_receive').default(0).notNull(),
 	sort: integer('sort').default(0).notNull(),
 	isDel: integer('is_del').default(0).notNull(),
+	forwardEmail: text('forward_email').default(''),
 });
 export default account

--- a/mail-worker/src/hono/hono.js
+++ b/mail-worker/src/hono/hono.js
@@ -6,6 +6,14 @@ import { cors } from 'hono/cors';
 
 app.use('*', cors());
 
+// Security headers
+app.use('*', async (c, next) => {
+	await next();
+	c.res.headers.set('X-Content-Type-Options', 'nosniff');
+	c.res.headers.set('X-Frame-Options', 'DENY');
+	c.res.headers.set('X-XSS-Protection', '1; mode=block');
+});
+
 app.onError((err, c) => {
 	if (err.name === 'BizError') {
 		console.log(err.message);

--- a/mail-worker/src/service/account-service.js
+++ b/mail-worker/src/service/account-service.js
@@ -264,6 +264,19 @@ const accountService = {
 		let mainSort = mainAccountRow.sort === 0 ? 2 : mainAccountRow.sort + 1;
 		await orm(c).update(account).set({ sort: mainSort }).where(eq(account.email, userRow.email )).run();
 		await orm(c).update(account).set({ sort: mainSort - 1 }).where(and(eq(account.accountId, accountId),eq(account.userId,userId))).run();
+	},
+
+	async setForward(c, params, userId) {
+		const { accountId, forwardEmail } = params;
+		const accountRow = await this.selectById(c, accountId);
+		if (!accountRow || accountRow.userId !== userId) {
+			throw new BizError(t('noUserAccount'));
+		}
+		if (forwardEmail && !verifyUtils.isEmail(forwardEmail)) {
+			throw new BizError(t('notEmail'));
+		}
+		await orm(c).update(account).set({ forwardEmail: forwardEmail || '' })
+			.where(and(eq(account.accountId, accountId), eq(account.userId, userId))).run();
 	}
 };
 

--- a/mail-worker/src/utils/rate-limiter.js
+++ b/mail-worker/src/utils/rate-limiter.js
@@ -1,0 +1,44 @@
+const rateLimiter = {
+
+	/**
+	 * Check if request exceeds rate limit using KV store
+	 * @param {object} env - Cloudflare env with kv binding
+	 * @param {string} key - Unique identifier (IP or userId)
+	 * @param {number} maxRequests - Max requests allowed in window
+	 * @param {number} windowSeconds - Time window in seconds
+	 * @returns {boolean} true if rate limited
+	 */
+	async isLimited(env, key, maxRequests = 10, windowSeconds = 60) {
+		const kvKey = `rl:${key}`;
+		const record = await env.kv.get(kvKey, { type: 'json' });
+
+		if (!record) {
+			await env.kv.put(kvKey, JSON.stringify({ count: 1, ts: Date.now() }), {
+				expirationTtl: windowSeconds
+			});
+			return false;
+		}
+
+		if (record.count >= maxRequests) {
+			return true;
+		}
+
+		record.count += 1;
+		const remaining = windowSeconds - Math.floor((Date.now() - record.ts) / 1000);
+		await env.kv.put(kvKey, JSON.stringify(record), {
+			expirationTtl: Math.max(remaining, 1)
+		});
+		return false;
+	},
+
+	/**
+	 * Get client IP from request
+	 */
+	getClientIp(c) {
+		return c.req.header('cf-connecting-ip') ||
+			c.req.header('x-forwarded-for')?.split(',')[0]?.trim() ||
+			'unknown';
+	}
+};
+
+export default rateLimiter;

--- a/mail-worker/src/utils/sanitize-utils.js
+++ b/mail-worker/src/utils/sanitize-utils.js
@@ -1,0 +1,36 @@
+const sanitizeUtils = {
+
+	/**
+	 * Sanitize string input — strip HTML tags and dangerous characters
+	 */
+	sanitizeString(input) {
+		if (typeof input !== 'string') return input;
+		return input
+			.replace(/[<>]/g, '')
+			.replace(/javascript:/gi, '')
+			.replace(/on\w+\s*=/gi, '')
+			.trim();
+	},
+
+	/**
+	 * Sanitize email address — only allow valid email characters
+	 */
+	sanitizeEmail(email) {
+		if (typeof email !== 'string') return '';
+		return email.replace(/[^a-zA-Z0-9@._+\-]/g, '').toLowerCase().trim();
+	},
+
+	/**
+	 * Sanitize object fields recursively (shallow, string fields only)
+	 */
+	sanitizeParams(params) {
+		if (!params || typeof params !== 'object') return params;
+		const clean = {};
+		for (const [key, value] of Object.entries(params)) {
+			clean[key] = typeof value === 'string' ? this.sanitizeString(value) : value;
+		}
+		return clean;
+	}
+};
+
+export default sanitizeUtils;


### PR DESCRIPTION
## Summary

This PR adds security hardening and a per-user email forwarding feature.

### Security Improvements

- **Rate Limiting** (KV-based, zero dependencies):
  - Login: 5 requests/minute per IP
  - Register: 3 requests/5 minutes per IP
  - Uses Cloudflare KV with TTL-based expiration

- **Input Sanitization** (`sanitize-utils.js`):
  - Strips HTML tags and dangerous patterns (XSS prevention)
  - Sanitizes email addresses
  - Applied to login/register params

- **Security Headers** (global middleware):
  - `X-Content-Type-Options: nosniff`
  - `X-Frame-Options: DENY`
  - `X-XSS-Protection: 1; mode=block`

### New Feature: Per-User Email Forwarding

- Adds `forward_email` field to the `account` table
- New endpoint: `PUT /account/setForward` — allows each user to configure their own forwarding address
- Forwarding executes after the global system-level forwarding
- Validates email format before saving

### Files Changed

- `mail-worker/src/utils/rate-limiter.js` (new)
- `mail-worker/src/utils/sanitize-utils.js` (new)
- `mail-worker/src/api/login-api.js` (rate limit + sanitize)
- `mail-worker/src/hono/hono.js` (security headers)
- `mail-worker/src/entity/account.js` (forwardEmail field)
- `mail-worker/src/api/account-api.js` (setForward endpoint)
- `mail-worker/src/service/account-service.js` (setForward logic)
- `mail-worker/src/email/email.js` (per-user forwarding)

### Notes

- No new dependencies added
- Rate limiter uses existing KV binding
- Backward compatible — forwardEmail defaults to empty string
- D1 migration needed: `ALTER TABLE account ADD COLUMN forward_email TEXT DEFAULT ''`