### PR TITLE
feat: add Turnstile CAPTCHA support for login

### DIFF
--- a/mail-vue/src/i18n/en.js
+++ b/mail-vue/src/i18n/en.js
@@ -168,6 +168,7 @@ const en = {
     turnstileSetting: 'Turnstile',
     signUpVerification: 'Sign Up Verification',
     addEmailVerification: 'Add Email Verification',
+    loginVerification: 'Login Verification',
     about: 'About',
     version: 'Version',
     community: 'Community',

--- a/mail-vue/src/i18n/zh.js
+++ b/mail-vue/src/i18n/zh.js
@@ -168,6 +168,7 @@ const zh = {
     turnstileSetting: 'Turnstile 人机验证',
     signUpVerification: '注册验证',
     addEmailVerification: '添加验证',
+    loginVerification: '登录验证',
     about: '关于',
     version: '版本',
     community: '交流',

--- a/mail-vue/src/request/login.js
+++ b/mail-vue/src/request/login.js
@@ -1,7 +1,7 @@
 import http from '@/axios/index.js';
 
-export function login(email, password) {
-    return http.post('/login', {email: email, password: password})
+export function login(email, password, token) {
+    return http.post('/login', {email: email, password: password, token: token})
 }
 
 export function logout() {

--- a/mail-vue/src/views/login/index.vue
+++ b/mail-vue/src/views/login/index.vue
@@ -42,14 +42,14 @@
           <el-input v-model="form.password" :placeholder="$t('password')" type="password" autocomplete="off">
           </el-input>
           <div v-show="loginVerifyShow"
-               class="register-turnstile"
+               class="login-turnstile"
                :data-sitekey="settingStore.settings.siteKey"
-               data-callback="onTurnstileSuccess"
-               data-error-callback="onTurnstileError"
+               data-callback="onLoginTurnstileSuccess"
+               data-error-callback="onLoginTurnstileError"
                data-after-interactive-callback="loadAfter"
                data-before-interactive-callback="loadBefore"
           >
-            <span style="font-size: 12px;color: #F56C6C" v-if="botJsError">{{ $t('verifyModuleFailed') }}</span>
+            <span style="font-size: 12px;color: #F56C6C" v-if="loginBotJsError">{{ $t('verifyModuleFailed') }}</span>
           </div>
           <el-button class="btn" type="primary" @click="submit" :loading="loginLoading"
           >{{ $t('loginBtn') }}
@@ -211,8 +211,11 @@ const verifyShow = ref(false)
 const loginVerifyShow = ref(false)
 let verifyToken = ''
 let turnstileId = null
+let loginTurnstileId = null
 let botJsError = ref(false)
+let loginBotJsError = ref(false)
 let verifyErrorCount = 0
+let loginVerifyErrorCount = 0
 
 window.onTurnstileSuccess = (token) => {
   verifyToken = token;
@@ -230,6 +233,27 @@ window.onTurnstileError = (e) => {
         turnstileId = window.turnstile.render('.register-turnstile')
       } else {
         window.turnstile.reset(turnstileId);
+      }
+    })
+  }, 1500)
+};
+
+window.onLoginTurnstileSuccess = (token) => {
+  verifyToken = token;
+};
+
+window.onLoginTurnstileError = (e) => {
+  if (loginVerifyErrorCount >= 4) {
+    return
+  }
+  loginVerifyErrorCount++
+  console.warn('登录人机验证加载失败', e)
+  setTimeout(() => {
+    nextTick(() => {
+      if (!loginTurnstileId) {
+        loginTurnstileId = window.turnstile.render('.login-turnstile')
+      } else {
+        window.turnstile.reset(loginTurnstileId);
       }
     })
   }, 1500)
@@ -431,8 +455,8 @@ const submit = () => {
     await saveToken(data.token)
   }).catch(res => {
     verifyToken = ''
-    if (turnstileId) {
-      window.turnstile.reset(turnstileId)
+    if (loginTurnstileId) {
+      window.turnstile.reset(loginTurnstileId)
     }
     if (res.code === 400) {
       refreshWebsiteConfig()
@@ -472,15 +496,15 @@ function refreshWebsiteConfig() {
     loginVerifyShow.value = loginVerify === 0 || (loginVerify === 2 && loginVerifyOpen)
     if (loginVerifyShow.value) {
       nextTick(() => {
-        if (!turnstileId) {
+        if (!loginTurnstileId) {
           try {
-            turnstileId = window.turnstile.render('.register-turnstile')
+            loginTurnstileId = window.turnstile.render('.login-turnstile')
           } catch (e) {
-            botJsError.value = true
-            console.log('人机验证js加载失败')
+            loginBotJsError.value = true
+            console.log('登录人机验证js加载失败')
           }
         } else {
-          window.turnstile.reset(turnstileId)
+          window.turnstile.reset(loginTurnstileId)
         }
       })
     }

--- a/mail-vue/src/views/login/index.vue
+++ b/mail-vue/src/views/login/index.vue
@@ -41,6 +41,16 @@
           </el-input>
           <el-input v-model="form.password" :placeholder="$t('password')" type="password" autocomplete="off">
           </el-input>
+          <div v-show="loginVerifyShow"
+               class="register-turnstile"
+               :data-sitekey="settingStore.settings.siteKey"
+               data-callback="onTurnstileSuccess"
+               data-error-callback="onTurnstileError"
+               data-after-interactive-callback="loadAfter"
+               data-before-interactive-callback="loadBefore"
+          >
+            <span style="font-size: 12px;color: #F56C6C" v-if="botJsError">{{ $t('verifyModuleFailed') }}</span>
+          </div>
           <el-button class="btn" type="primary" @click="submit" :loading="loginLoading"
           >{{ $t('loginBtn') }}
           </el-button>
@@ -198,6 +208,7 @@ const domainList = settingStore.domainList;
 const registerLoading = ref(false)
 suffix.value = domainList[0]
 const verifyShow = ref(false)
+const loginVerifyShow = ref(false)
 let verifyToken = ''
 let turnstileId = null
 let botJsError = ref(false)
@@ -392,9 +403,29 @@ const submit = () => {
     return
   }
 
+  if (!verifyToken && loginVerifyShow.value) {
+    if (!botJsError.value) {
+      ElMessage({
+        message: t('botVerifyMsg'),
+        type: "error",
+        plain: true
+      })
+    }
+    loginLoading.value = false
+    return
+  }
+
   loginLoading.value = true
-  login(email, form.password).then(async data => {
+  login(email, form.password, verifyToken).then(async data => {
     await saveToken(data.token)
+  }).catch(res => {
+    verifyToken = ''
+    if (turnstileId) {
+      window.turnstile.reset(turnstileId)
+    }
+    if (res.code === 400) {
+      refreshWebsiteConfig()
+    }
   }).finally(() => {
     loginLoading.value = false
   })
@@ -425,6 +456,23 @@ function refreshWebsiteConfig() {
       suffix.value = setting.domainList[0]
     }
     document.title = setting.title
+    const loginVerify = setting.loginVerify
+    const loginVerifyOpen = setting.loginVerifyOpen
+    loginVerifyShow.value = loginVerify === 0 || (loginVerify === 2 && loginVerifyOpen)
+    if (loginVerifyShow.value) {
+      nextTick(() => {
+        if (!turnstileId) {
+          try {
+            turnstileId = window.turnstile.render('.register-turnstile')
+          } catch (e) {
+            botJsError.value = true
+            console.log('人机验证js加载失败')
+          }
+        } else {
+          window.turnstile.reset(turnstileId)
+        }
+      })
+    }
   }).catch(e => {
     console.error(e)
   })

--- a/mail-vue/src/views/sys-setting/index.vue
+++ b/mail-vue/src/views/sys-setting/index.vue
@@ -321,6 +321,25 @@
                 </div>
               </div>
               <div class="setting-item">
+                <div><span>{{ $t('loginVerification') }}</span></div>
+                <div>
+                  <el-button class="opt-button" size="small" type="primary" @click="openLoginVerifyCount">
+                    <Icon icon="fluent:settings-48-regular" width="18" height="18"/>
+                  </el-button>
+                  <el-select
+                      @change="change"
+                      :style="`width: ${ locale === 'en' ? 100 : 80 }px;`"
+                      v-model="setting.loginVerify"
+                      placeholder="Select"
+                      class="bot-verify-select"
+                  >
+                    <el-option key="1" :value="0" :label="$t('enable')"/>
+                    <el-option key="1" :value="1" :label="$t('disable')"/>
+                    <el-option key="1" :value="2" :label="$t('rulesVerify')"/>
+                  </el-select>
+                </div>
+              </div>
+              <div class="setting-item">
                 <div><span>Site Key</span></div>
                 <div class="bot-verify">
                   <span>{{ setting.siteKey }}</span>
@@ -649,6 +668,13 @@
           <el-button type="primary" :loading="settingLoading" @click="saveAddVerifyCount">{{ $t('save') }}</el-button>
         </form>
       </el-dialog>
+      <el-dialog v-model="loginVerifyCountShow" :title="$t('rulesVerifyTitle',{count: loginVerifyCount})"
+                 @closed="loginVerifyCount = setting.loginVerifyCount">
+        <form>
+          <el-input-number type="text" v-model="loginVerifyCount" :min="1"/>
+          <el-button type="primary" :loading="settingLoading" @click="saveLoginVerifyCount">{{ $t('save') }}</el-button>
+        </form>
+      </el-dialog>
       <el-dialog top="5vh" v-model="noticePopupShow" :title="$t('noticePopup')" class="notice-popup"
                  @closed="resetNoticeForm">
         <form>
@@ -862,10 +888,12 @@ let backgroundFile = {}
 const showSetBackground = ref(false)
 let regVerifyCount = ref(1)
 let addVerifyCount = ref(1)
+let loginVerifyCount = ref(3)
 let backup = '{}'
 const addS3Show = ref(false)
 const addVerifyCountShow = ref(false)
 const regVerifyCountShow = ref(false)
+const loginVerifyCountShow = ref(false)
 const resendTokenForm = reactive({
   domain: '',
   token: '',
@@ -953,6 +981,7 @@ function getSettings() {
     r2DomainInput.value = setting.value.r2Domain
     addVerifyCount.value = setting.value.addVerifyCount
     regVerifyCount.value = setting.value.regVerifyCount
+    loginVerifyCount.value = setting.value.loginVerifyCount
     resetNoticeForm()
     resetAddS3Form()
     resetEmailPrefix()
@@ -977,6 +1006,11 @@ function openAddVerifyCount() {
 function openRegVerifyCount() {
   if (settingLoading.value) return
   regVerifyCountShow.value = true
+}
+
+function openLoginVerifyCount() {
+  if (settingLoading.value) return
+  loginVerifyCountShow.value = true
 }
 
 function resetAddS3Form() {
@@ -1036,6 +1070,13 @@ function saveRegVerifyCount() {
     regVerifyCount.value = 1
   }
   editSetting({regVerifyCount: regVerifyCount.value})
+}
+
+function saveLoginVerifyCount() {
+  if (!loginVerifyCount.value) {
+    loginVerifyCount.value = 3
+  }
+  editSetting({loginVerifyCount: loginVerifyCount.value})
 }
 
 const compareByLengthAndUpperCase = (a, b, key) => {
@@ -1488,6 +1529,7 @@ function editSetting(settingForm, refreshStatus = true) {
     forwardRulesShow.value = false
     addVerifyCountShow.value = false
     regVerifyCountShow.value = false
+    loginVerifyCountShow.value = false
     noticePopupShow.value = false
     addS3Show.value = false
     emailPrefixShow.value = false

--- a/mail-worker/src/const/entity-const.js
+++ b/mail-worker/src/const/entity-const.js
@@ -141,6 +141,7 @@ export const settingConst = {
 export const verifyRecordType = {
 	REG: 0,
 	ADD: 1,
+	LOGIN: 2,
 }
 
 

--- a/mail-worker/src/entity/setting.js
+++ b/mail-worker/src/entity/setting.js
@@ -51,6 +51,8 @@ export const setting = sqliteTable('setting', {
 	blackContent: text('black_content').default('').notNull(),
 	blackFrom: text('black_from').default('').notNull(),
 	aiCode: integer('ai_code').default(1).notNull(),
-	aiCodeFilter: text('ai_code_filter').default('').notNull()
+	aiCodeFilter: text('ai_code_filter').default('').notNull(),
+	loginVerify: integer('login_verify').default(1).notNull(),
+	loginVerifyCount: integer('login_verify_count').default(3).notNull()
 });
 export default setting

--- a/mail-worker/src/init/init.js
+++ b/mail-worker/src/init/init.js
@@ -29,8 +29,22 @@ const dbInit = {
 		await this.v2_8DB(c);
 		await this.v2_9DB(c);
 		await this.v3_0DB(c);
+		await this.v3_1DB(c);
 		await settingService.refresh(c);
 		return c.text('success');
+	},
+
+	async v3_1DB(c) {
+		try {
+			await c.env.db.prepare(`ALTER TABLE setting ADD COLUMN login_verify INTEGER NOT NULL DEFAULT 1;`).run();
+		} catch (e) {
+			console.warn(`跳过字段：${e.message}`);
+		}
+		try {
+			await c.env.db.prepare(`ALTER TABLE setting ADD COLUMN login_verify_count INTEGER NOT NULL DEFAULT 3;`).run();
+		} catch (e) {
+			console.warn(`跳过字段：${e.message}`);
+		}
 	},
 
 	async v3_0DB(c) {

--- a/mail-worker/src/service/login-service.js
+++ b/mail-worker/src/service/login-service.js
@@ -201,29 +201,61 @@ const loginService = {
 
 	async login(c, params, noVerifyPwd = false) {
 
-		const { email, password } = params;
+		const { email, password, token } = params;
 
 		if ((!email || !password) && !noVerifyPwd) {
 			throw new BizError(t('emailAndPwdEmpty'));
 		}
 
+		let { loginVerify, loginVerifyCount } = await settingService.query(c)
+
+		if (noVerifyPwd) {
+			loginVerify = settingConst.registerVerify.CLOSE;
+		}
+
+		let loginVerifyOpen = false
+
+		if (loginVerify === settingConst.registerVerify.OPEN) {
+			loginVerifyOpen = true
+			await turnstileService.verify(c,token)
+		}
+
+		if (loginVerify === settingConst.registerVerify.COUNT) {
+			loginVerifyOpen = await verifyRecordService.isOpenLoginVerify(c, loginVerifyCount);
+			if (loginVerifyOpen) {
+				await turnstileService.verify(c,token)
+			}
+		}
+
 		const userRow = await userService.selectByEmailIncludeDel(c, email);
 
 		if (!userRow) {
+			if (!noVerifyPwd) {
+				await verifyRecordService.increaseLoginCount(c);
+			}
 			throw new BizError(t('notExistUser'));
 		}
 
 		if(userRow.isDel === isDel.DELETE) {
+			if (!noVerifyPwd) {
+				await verifyRecordService.increaseLoginCount(c);
+			}
 			throw new BizError(t('isDelUser'));
 		}
 
 		if(userRow.status === userConst.status.BAN) {
+			if (!noVerifyPwd) {
+				await verifyRecordService.increaseLoginCount(c);
+			}
 			throw new BizError(t('isBanUser'));
 		}
 
 		if (!await cryptoUtils.verifyPassword(password, userRow.salt, userRow.password) && !noVerifyPwd) {
+			await verifyRecordService.increaseLoginCount(c);
 			throw new BizError(t('IncorrectPwd'));
 		}
+
+		await verifyRecordService.clearLoginCount(c);
 
 		const uuid = uuidv4();
 		const jwt = await JwtUtils.generateToken(c,{ userId: userRow.userId, token: uuid });

--- a/mail-worker/src/service/setting-service.js
+++ b/mail-worker/src/service/setting-service.js
@@ -105,6 +105,7 @@ const settingService = {
 
 		let regVerifyOpen = false
 		let addVerifyOpen = false
+		let loginVerifyOpen = false
 
 		recordList.forEach(row => {
 			if (row.type === verifyRecordType.REG) {
@@ -113,10 +114,14 @@ const settingService = {
 			if (row.type === verifyRecordType.ADD) {
 				addVerifyOpen = row.count >= settingRow.addVerifyCount
 			}
+			if (row.type === verifyRecordType.LOGIN) {
+				loginVerifyOpen = row.count >= settingRow.loginVerifyCount
+			}
 		})
 
 		settingRow.regVerifyOpen = regVerifyOpen
 		settingRow.addVerifyOpen = addVerifyOpen
+		settingRow.loginVerifyOpen = loginVerifyOpen
 
 		settingRow.storageType = await r2Service.storageType(c);
 
@@ -218,6 +223,9 @@ const settingService = {
 			regKey: settingRow.regKey,
 			regVerifyOpen: settingRow.regVerifyOpen,
 			addVerifyOpen: settingRow.addVerifyOpen,
+			loginVerify: settingRow.loginVerify,
+			loginVerifyCount: settingRow.loginVerifyCount,
+			loginVerifyOpen: settingRow.loginVerifyOpen,
 			noticeTitle: settingRow.noticeTitle,
 			noticeContent: settingRow.noticeContent,
 			noticeType: settingRow.noticeType,

--- a/mail-worker/src/service/verify-record-service.js
+++ b/mail-worker/src/service/verify-record-service.js
@@ -83,6 +83,46 @@ const verifyRecordService = {
 		} else {
 			return orm(c).insert(verifyRecord).values({ip, type: verifyRecordType.ADD}).returning().get();
 		}
+	},
+
+	async isOpenLoginVerify(c, loginVerifyCount) {
+
+		const ip = reqUtils.getIp(c)
+
+		const row = await orm(c).select().from(verifyRecord).where(and(eq(verifyRecord.ip, ip),eq(verifyRecord.type,verifyRecordType.LOGIN))).get();
+
+		if (row) {
+			if (row.count >= loginVerifyCount){
+				return true
+			}
+		}
+
+		return false
+
+	},
+
+	async increaseLoginCount(c) {
+
+		const ip = reqUtils.getIp(c)
+
+		const row = await orm(c).select().from(verifyRecord).where(and(eq(verifyRecord.ip, ip),eq(verifyRecord.type,verifyRecordType.LOGIN))).get();
+		const now = dayjs().format('YYYY-MM-DD HH:mm:ss');
+
+		if (row) {
+			return orm(c).update(verifyRecord).set({
+				count: sql`${verifyRecord.count}
+		+ 1`, updateTime: now
+			}).where(and(eq(verifyRecord.ip, ip),eq(verifyRecord.type,verifyRecordType.LOGIN))).returning().get();
+		} else {
+			return orm(c).insert(verifyRecord).values({ip, type: verifyRecordType.LOGIN}).returning().run();
+		}
+	},
+
+	async clearLoginCount(c) {
+
+		const ip = reqUtils.getIp(c)
+
+		await orm(c).delete(verifyRecord).where(and(eq(verifyRecord.ip, ip),eq(verifyRecord.type,verifyRecordType.LOGIN))).run();
 	}
 
 };


### PR DESCRIPTION
## Summary

Add Turnstile human verification for the `/api/login` endpoint to protect against brute-force attacks.

## Motivation

Currently, the login endpoint (`POST /api/login`) has no CAPTCHA protection, making it vulnerable to automated brute-force attacks. This PR extends the existing Turnstile verification infrastructure (already used for registration) to also cover login.

## Changes

### Backend

- **Database**: Add `login_verify` and `login_verify_count` columns to `setting` table
- **Migration**: Add `login_verify` and `login_verify_count` fields to `v3_1DB()` in `init.js`
- **Entity**: Add `verifyRecordType.LOGIN = 2`
- **Service**: 
  - `verify-record-service.js`: Add `isOpenLoginVerify`, `increaseLoginCount`, `clearLoginCount`
  - `login-service.js`: Verify Turnstile token before password check; increment failure count on error; clear on success
  - `setting-service.js`: Return `loginVerifyOpen` in `get()` and `websiteConfig()`

### Frontend

- **Login page**: Conditionally render Turnstile widget based on `loginVerify` config
- **API**: Pass `token` param in `login()` request
- **Admin settings**: Add "Login Verification" config UI (same pattern as Register Verification)
- **i18n**: Add `loginVerification` key (zh/en)

## Verification Modes

| Mode             | Value | Behavior                                                     |
| ---------------- | ----- | ------------------------------------------------------------ |
| Always ON        | 0     | Always require CAPTCHA                                       |
| Always OFF       | 1     | Never require CAPTCHA (default)                              |
| After N failures | 2     | Require CAPTCHA after `loginVerifyCount` failures from same IP |

## Backwards Compatibility

- Default `login_verify = 1` (CLOSE): existing users are unaffected
- `/login` accepts optional `token` param: old clients work without changes
- New DB columns use `DEFAULT` values: safe for existing deployments

## Testing

- [x] Login without CAPTCHA works when `loginVerify = CLOSE`
- [x] Login with CAPTCHA works when `loginVerify = OPEN`
- [x] COUNT mode triggers CAPTCHA after N failures
- [x] Login success clears failure count
- [x] Admin settings page correctly saves and displays config