### PR TITLE
Security: Bug in R2 URL conversion function

### DIFF
--- a/mail-vue/src/utils/convert.js
+++ b/mail-vue/src/utils/convert.js
@@ -2,7 +2,7 @@ import {useSettingStore} from "@/store/setting.js";
 export function cvtR2Url(key) {
 
     if (!key) {
-        return + 'https://' + ''
+        return ''
     }
 
     if (key.startsWith('https://')) {


### PR DESCRIPTION
## Problem

In mail-vue/src/utils/convert.js, the cvtR2Url function has a bug: `return + 'https://' + ''` will evaluate to NaN due to the unary + operator. This will cause incorrect URL generation when key is falsy.

**Severity**: `medium`
**File**: `mail-vue/src/utils/convert.js`

## Solution

Change `return + 'https://' + ''` to `return ''` or handle the null case properly

## Changes

- `mail-vue/src/utils/convert.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
