### PR TITLE
Security: IP address stored as integer instead of text

### DIFF
--- a/mail-worker/src/entity/verify-record.js
+++ b/mail-worker/src/entity/verify-record.js
@@ -2,7 +2,7 @@ import { sqliteTable, text, integer} from 'drizzle-orm/sqlite-core';
 import { sql } from 'drizzle-orm';
 export const email = sqliteTable('verify_record', {
 	vrId: integer('vr_id').primaryKey({ autoIncrement: true }),
-	ip: integer('ip').notNull().default(''),
+	ip: text('ip').notNull().default(''),
 	count: integer('count').notNull().default(1),
 	type: integer('type').notNull().default(0),
 	updateTime: text('update_time').default(sql`CURRENT_TIMESTAMP`).notNull(),


### PR DESCRIPTION
## Problem

In mail-worker/src/entity/verify-record.js, the ip field is defined as integer('ip') but IP addresses are strings. This will cause data loss or conversion errors when storing IPv4 or IPv6 addresses.

**Severity**: `high`
**File**: `mail-worker/src/entity/verify-record.js`

## Solution

Change `ip: integer('ip')` to `ip: text('ip')` to properly store IP addresses

## Changes

- `mail-worker/src/entity/verify-record.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
