### PR TITLE
i18n: translate remaining Chinese text to English

### DIFF
--- a/mail-vue/src/components/email-scroll/index.vue
+++ b/mail-vue/src/components/email-scroll/index.vue
@@ -409,7 +409,7 @@ watch(scrollbarRef, () => {
   updateHasScrollbar();
 })
 
-// 强制刷新 (itemHeight 更改后虚拟滚动列表不会自己更新)
+// Force refresh (virtual scroll list won't update on its own after itemHeight changes)
 watch(itemHeight, () => {
   keyCount.value ++
 })
@@ -439,7 +439,7 @@ watch(noLoading, (isNoLoading) => {
 })
 
 
-// 监听是否到达底部
+// Listen for reaching the bottom
 watch(() => arrivedState.bottom, (isBottom) => {
   if (isBottom && !loading.value) {
     loadData();
@@ -577,8 +577,8 @@ function htmlToText(email) {
 
 function cleanSpace(text) {
   return text
-      .replace(/[\u200B-\u200F\uFEFF\u034F\u200B-\u200F\u00A0\u3000\u00AD]/g, '')// 移除零宽空格
-      .replace(/\s+/g, ' ')                   // 多空白合并成一个空格
+      .replace(/[\u200B-\u200F\uFEFF\u034F\u200B-\u200F\u00A0\u3000\u00AD]/g, '')// Remove zero-width spaces
+      .replace(/\s+/g, ' ')                   // Collapse multiple spaces into one
       .trim();
 }
 
@@ -774,7 +774,7 @@ function handleCheckAllChange(val) {
   isIndeterminate.value = false;
 }
 
-// 获取选中的邮件列表id
+// Get selected email list IDs
 function getSelectedMailsIds() {
   return emailList.filter(item => item.checked).map(item => item.emailId);
 }
@@ -996,7 +996,7 @@ function loadData() {
   }
 
   @media (pointer: coarse) {
-    /* 触屏 */
+    /* Touch screen */
     user-select: none;
   }
   &.all-email {

--- a/mail-vue/src/components/shadow-html/index.vue
+++ b/mail-vue/src/components/shadow-html/index.vue
@@ -21,15 +21,15 @@ let shadowRoot = null
 function updateContent() {
   if (!shadowRoot) return;
 
-  // 1. 提取 <body> 的 style 属性（如果存在）
+  // 1. Extract <body> style attribute (if present)
   const bodyStyleRegex = /<body[^>]*style="([^"]*)"[^>]*>/i;
   const bodyStyleMatch = props.html.match(bodyStyleRegex);
   const bodyStyle = bodyStyleMatch ? bodyStyleMatch[1] : '';
 
-  // 2. 移除 <body> 标签（保留内容）
+  // 2. Remove <body> tags (keep content)
   const cleanedHtml = props.html.replace(/<\/?body[^>]*>/gi, '');
 
-  // 3. 将 body 的 style 应用到 .shadow-content
+  // 3. Apply body style to .shadow-content
   shadowRoot.innerHTML = `
     <style>
       :host {
@@ -63,7 +63,7 @@ function updateContent() {
         width: fit-content;
         height: fit-content;
         min-width: 100%;
-        ${bodyStyle ? bodyStyle : ''} /* 注入 body 的 style */
+        ${bodyStyle ? bodyStyle : ''}
       }
 
       img:not(table img) {

--- a/mail-vue/src/components/tiny-editor/index.vue
+++ b/mail-vue/src/components/tiny-editor/index.vue
@@ -91,8 +91,8 @@ function initEditor() {
     statusbar: false,
     height: "100%",
     auto_focus: true,
-    //relative_urls: false,  //阻止 img标签域名和网站域名相同 自动把链接转换相对路径
-    //remove_script_host: false, // 阻止删除 URL 中的域名
+    //relative_urls: false,  // Prevent auto-converting absolute img URLs to relative paths
+    //remove_script_host: false, // Prevent removing the host from URLs
     forced_root_block: 'div',
     skin: `${uiStore.dark ? 'oxide-dark' : 'oxide'}`,
     content_css: `/tinymce/css/index.css,${uiStore.dark ? 'dark' : 'default'}`,

--- a/mail-vue/src/echarts/index.js
+++ b/mail-vue/src/echarts/index.js
@@ -2,16 +2,16 @@
 import * as echarts from 'echarts/core';
 
 import { BarChart,PieChart,LineChart,GaugeChart} from 'echarts/charts';
-// 引入标题，提示框，直角坐标系，数据集，内置数据转换器组件，组件后缀都为 Component
+// Import tooltip, grid and other components (suffix: Component)
 import {
     TooltipComponent,
     GridComponent,
 } from 'echarts/components';
-// 标签自动布局、全局过渡动画等特性
-// 引入 Canvas 渲染器，注意引入 CanvasRenderer 或者 SVGRenderer 是必须的一步
+// Label auto layout, global transition animations, etc.
+// Import Canvas renderer — either CanvasRenderer or SVGRenderer is required
 import { CanvasRenderer } from 'echarts/renderers';
 import { LegendComponent } from 'echarts/components';
-// 注册必须的组件
+// Register required components
 echarts.use([
     GaugeChart,
     LegendComponent,

--- a/mail-vue/src/i18n/en.js
+++ b/mail-vue/src/i18n/en.js
@@ -337,7 +337,16 @@ const en = {
     searchUser: 'Search by user',
     searchEmail: 'Search by Email',
     searchSender: 'Search by Sender',
-    userEmail: 'Email Address'
+    userEmail: 'Email Address',
+    avatar: 'Profile Picture',
+    uploadAvatar: 'Upload',
+    deleteAvatar: 'Remove',
+    avatarDesc: 'Supports JPG, PNG, GIF, WebP (max 5MB)',
+    deleteAvatarConfirm: 'Remove profile picture?',
+    avatarTypeError: 'Only image files are supported',
+    avatarTooLarge: 'Image must be less than 5MB',
+    avatarUploadSuccess: 'Profile picture updated',
+    avatarDeleteSuccess: 'Profile picture removed'
 }
 
 export default en

--- a/mail-vue/src/i18n/zh.js
+++ b/mail-vue/src/i18n/zh.js
@@ -337,6 +337,15 @@ const zh = {
     searchUser: '搜索用户',
     searchEmail: '搜索邮箱',
     searchSender: '搜索发件人',
-    userEmail: '用户邮箱'
+    userEmail: '用户邮箱',
+    avatar: '头像',
+    uploadAvatar: '上传',
+    deleteAvatar: '删除',
+    avatarDesc: '支持 JPG、PNG、GIF、WebP（最大 5MB）',
+    deleteAvatarConfirm: '确认删除头像？',
+    avatarTypeError: '只支持图片文件',
+    avatarTooLarge: '图片大小不能超过5MB',
+    avatarUploadSuccess: '头像更新成功',
+    avatarDeleteSuccess: '头像已删除'
 }
 export default zh

--- a/mail-vue/src/layout/account/index.vue
+++ b/mail-vue/src/layout/account/index.vue
@@ -205,7 +205,7 @@ window.onTurnstileError = (e) => {
     return
   }
   verifyErrorCount++
-  console.warn('人机验加载失败', e)
+  console.warn('CAPTCHA failed to load', e)
   setTimeout(() => {
     nextTick(() => {
       if (!turnstileId) {
@@ -463,7 +463,7 @@ function submit() {
             turnstileId = window.turnstile.render('.add-email-turnstile')
           } catch (e) {
             botJsError.value = true
-            console.log('人机验证js加载失败')
+            console.log('CAPTCHA script failed to load')
           }
         } else {
           window.turnstile.reset('.add-email-turnstile')

--- a/mail-vue/src/layout/header/index.vue
+++ b/mail-vue/src/layout/header/index.vue
@@ -208,7 +208,7 @@ function openDark(e) {
   const maxY = Math.max(y, window.innerHeight - y)
   const endRadius = Math.hypot(maxX, maxY)
 
-  // 标记切换目标，供 CSS 选择器使用
+  // Mark the switch target for CSS selector
   root.setAttribute('data-theme-to', nextIsDark ? 'dark' : 'light')
   root.style.setProperty('--vt-x', `${x}px`)
   root.style.setProperty('--vt-y', `${y}px`)
@@ -219,7 +219,7 @@ function openDark(e) {
   })
 
   transition.finished.finally(() => {
-    // 清理标记
+    // Clean up marker
     root.removeAttribute('data-theme-to')
   })
 }

--- a/mail-vue/src/layout/header/index.vue
+++ b/mail-vue/src/layout/header/index.vue
@@ -22,14 +22,16 @@
       <el-dropdown ref="userinfoRef" @visible-change="e => userInfoShow = e" :teleported="false" popper-class="detail-dropdown">
         <div class="avatar" @click="userInfoHide" >
           <div class="avatar-text">
-            <div>{{ formatName(userStore.user.email) }}</div>
+            <img v-if="userStore.user.avatar" :src="userStore.user.avatar" class="avatar-img" alt="avatar"/>
+            <div v-else>{{ formatName(userStore.user.email) }}</div>
           </div>
           <Icon class="setting-icon" icon="mingcute:down-small-fill" width="24" height="24"/>
         </div>
         <template #dropdown>
           <div class="user-details">
             <div class="details-avatar">
-              {{ formatName(userStore.user.email) }}
+              <img v-if="userStore.user.avatar" :src="userStore.user.avatar" class="details-avatar-img" alt="avatar"/>
+              <span v-else>{{ formatName(userStore.user.email) }}</span>
             </div>
             <div class="user-name">
               {{ userStore.user.name }}
@@ -351,6 +353,13 @@ function formatName(email) {
     align-items: center;
     justify-content: center;
     border-radius: 10px;
+    overflow: hidden;
+
+    .details-avatar-img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
   }
 }
 
@@ -461,6 +470,13 @@ function formatName(email) {
       align-items: center;
       border-radius: 8px;
       border: 1px solid var(--dark-border);
+      overflow: hidden;
+
+      .avatar-img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
     }
 
     .setting-icon {

--- a/mail-vue/src/request/my.js
+++ b/mail-vue/src/request/my.js
@@ -12,3 +12,13 @@ export function userDelete() {
     return http.delete('/my/delete')
 }
 
+export function uploadAvatar(file) {
+    const form = new FormData()
+    form.append('file', file)
+    return http.put('/my/avatar', form, { headers: { 'Content-Type': 'multipart/form-data' } })
+}
+
+export function deleteAvatar() {
+    return http.delete('/my/avatar')
+}
+

--- a/mail-vue/src/router/index.js
+++ b/mail-vue/src/router/index.js
@@ -78,9 +78,9 @@ const router = createRouter({
 })
 
 NProgress.configure({
-    showSpinner: false,   // 不显示旋转图标
-    trickleSpeed: 50,    // 自动递增速度
-    minimum: 0.1          // 最小百分比
+    showSpinner: false,
+    trickleSpeed: 50,
+    minimum: 0.1
 });
 
 let timer
@@ -133,12 +133,12 @@ function loadBackground(next) {
         };
 
         img.onerror = () => {
-            console.warn("背景图片加载失败:", img.src);
+            console.warn("Background image failed to load:", img.src);
             next()
         };
 
         setTimeout(() => {
-            console.warn("背景加载超时，已放行");
+            console.warn("Background load timed out, proceeding");
             next()
         }, 3000)
 

--- a/mail-vue/src/utils/text.js
+++ b/mail-vue/src/utils/text.js
@@ -1,8 +1,8 @@
 export function getTextWidth(text, font = '14px sans-serif') {
-    // 强制设置 Canvas 分辨率
+    // Force canvas resolution
     const canvas = document.createElement('canvas');
-    canvas.width = 2000; // 足够大的画布
-    canvas.style.width = '1000px'; // 避免 CSS 缩放影响
+    canvas.width = 2000;
+    canvas.style.width = '1000px';
     const ctx = canvas.getContext('2d');
     ctx.font = font;
     return ctx.measureText(text).width;

--- a/mail-vue/src/views/all-email/index.vue
+++ b/mail-vue/src/views/all-email/index.vue
@@ -332,7 +332,7 @@ async function latest() {
         continue
       }
 
-      // 确保回来之后条件没变
+      // Ensure conditions have not changed after response
       if (params.timeSort !== curTimeSort) {
         continue
       }
@@ -365,11 +365,11 @@ async function latest() {
 
   .my-date-picker::after {
     content: "";
-    position: absolute; /* 脱离文档流，不会撑开 */
+    position: absolute;
     left: 0;
     right: 0;
     height: 20px;
-    background: transparent; /* 方便看效果 */
+    background: transparent;
   }
 
   .el-date-range-picker__content {

--- a/mail-vue/src/views/analysis/index.vue
+++ b/mail-vue/src/views/analysis/index.vue
@@ -88,8 +88,8 @@
             <span>{{ $t('emailSource') }}</span>
             <span class="source-button" v-if="false">
               <el-radio-group v-model="checkedSourceType">
-                <el-radio-button label="发件人" value="sender"/>
-                <el-radio-button label="邮箱" value="email"/>
+                <el-radio-button label="Sender" value="sender"/>
+                <el-radio-button label="Email" value="email"/>
               </el-radio-group>
             </span>
           </div>
@@ -361,10 +361,10 @@ function createSenderPie() {
         },
         label: {
           show: false,
-          position: 'outside', // 标签显示在外部
-          formatter: '{d}%',  // 显示名称和占比
+          position: 'outside',
+          formatter: '{d}%',
           color: '#333',
-          fontSize: 14  // 设置字体大小
+          fontSize: 14
         },
         emphasis: {
           label: {
@@ -376,7 +376,7 @@ function createSenderPie() {
         labelLine: {
           show: true
         },
-        color: ['#3CB2FF', '#13DEB9', '#FBBF24', '#FF7F50', '#BAE6FD', '#C084FC'] // 添加符合主题的配色
+        color: ['#3CB2FF', '#13DEB9', '#FBBF24', '#FF7F50', '#BAE6FD', '#C084FC']
       }
     ]
   }
@@ -393,14 +393,14 @@ function createIncreaseLine() {
 
   let option = {
     tooltip: {
-      trigger: 'axis', // 设置触发方式为 'axis'，在坐标轴上显示信息
+      trigger: 'axis',
       axisPointer: {
-        type: 'cross', // 指示器的类型为交叉型，适用于折线图等
+        type: 'cross',
         crossStyle: {
-          color: topic.value.crossColor// 设置指示器线的颜色
+          color: topic.value.crossColor
         },
         lineStyle: {
-          color: topic.value.crossColor         // ← 竖线颜色
+          color: topic.value.crossColor
         },
         axis: 'x',
       },
@@ -411,12 +411,12 @@ function createIncreaseLine() {
         });
         return result;
       },
-      backgroundColor: topic.value.background,  // 设置背景颜色
-      borderColor: topic.value.splitLineColor,      // 设置边框颜色
-      borderWidth: 1,           // 设置边框宽度
-      padding: 10,              // 设置内边距
+      backgroundColor: topic.value.background,
+      borderColor: topic.value.splitLineColor,
+      borderWidth: 1,
+      padding: 10,
       textStyle: {
-        color: topic.value.color,          // 设置文字颜色
+        color: topic.value.color,
       }
     },
     grid: {
@@ -430,7 +430,7 @@ function createIncreaseLine() {
       data: userLineData.xdata,
       axisTick: {
         show: false,
-        alignWithLabel: false,  // 刻度线与标签对齐,
+        alignWithLabel: false,
         lineStyle: {
           color: topic.value.axisColor,
         }
@@ -464,7 +464,7 @@ function createIncreaseLine() {
     yAxis: {
       type: 'value',
       axisLabel: {
-        margin: 5, // 增加y轴刻度数字与网格线之间的间距
+        margin: 5,
       },
       boundaryGap: [0, 0.1],
       max: (params) => {
@@ -488,10 +488,10 @@ function createIncreaseLine() {
         }
       },
       splitLine: {
-        show: true, // 显示网格线
+        show: true,
         lineStyle: {
-          type: 'dashed', // 设置网格线为虚线
-          color: topic.value.scaleLineColor   // 设置虚线的颜色
+          type: 'dashed',
+          color: topic.value.scaleLineColor
         }
       }
     },
@@ -563,7 +563,7 @@ function createEmailColumnChart() {
       data: [t('emailReceived'), t('emailSent')],
       top: '0',
       textStyle: {
-        color: topic.value.color,  // 图例文字颜色
+        color: topic.value.color,
       }
     },
     grid: {
@@ -596,8 +596,8 @@ function createEmailColumnChart() {
       splitLine: {
         show: true,
         lineStyle: {
-          color: topic.value.splitLineColor,  // ← 横线颜色
-          type: 'solid',    // dashed=虚线，solid=实线
+          color: topic.value.splitLineColor,
+          type: 'solid',
           width: 1
         }
       },
@@ -615,7 +615,7 @@ function createEmailColumnChart() {
       {
         name: t('emailReceived'),
         type: 'bar',
-        stack: 'total', // 堆叠组标识（必须相同）
+        stack: 'total',
         barWidth: '60%',
         barMaxWidth: 30,
         emphasis: {
@@ -632,7 +632,7 @@ function createEmailColumnChart() {
       {
         name: t('emailSent'),
         type: 'bar',
-        stack: 'total', // 堆叠组标识（必须相同）
+        stack: 'total',
         emphasis: {
           itemStyle: {
             shadowBlur: 10,
@@ -666,7 +666,7 @@ function createSendGauge() {
       name: t('sentToday'),
       type: 'gauge',
       max: 100,
-      // 进度条颜色（新增）
+      // Progress bar color
       progress: {
         show: true,
         roundCap: true,
@@ -674,7 +674,7 @@ function createSendGauge() {
           color: '#3CB2FF'
         }
       },
-      // 指针颜色（新增）
+      // Pointer color
       pointer: {
         itemStyle: {
           color: '#3CB2FF'
@@ -683,7 +683,7 @@ function createSendGauge() {
       axisLabel: {
         color: topic.value.gaugeSplitLine,
       },
-      // 轴线背景色（新增）
+      // Axis background color
       axisLine: {
         roundCap: true,
         lineStyle: {
@@ -692,27 +692,27 @@ function createSendGauge() {
       },
       splitLine: {
         lineStyle: {
-          color: topic.value.gaugeSplitLine, // 大刻度线颜色
+          color: topic.value.gaugeSplitLine,
         }
       },
-      // 刻度颜色（新增）
+      // Scale tick color
       axisTick: {
         lineStyle: {
           color: topic.value.axisColor
         }
       },
-      // 中心文字颜色（新增）
+      // Center text color
       detail: {
         valueAnimation: true,
         formatter: '{value}',
-        color: topic.value.color // 黑色文字
+        color: topic.value.color
       },
       data: [{
         value: daySendTotal,
         name: t('total'),
-        // 名称标签颜色（新增）
+        // Name label color
         title: {
-          color: topic.value.color  // 灰色标签
+          color: topic.value.color
         }
       }]
     }],

--- a/mail-vue/src/views/content/index.vue
+++ b/mail-vue/src/views/content/index.vue
@@ -409,8 +409,8 @@ const handleDelete = () => {
   left: 0;
   right: 0;
   bottom: 0;
-  background: var(--message-block-color); /* 半透明黑色蒙层 */
-  pointer-events: none; /* 不影响点击 */
+  background: var(--message-block-color);
+  pointer-events: none;
 }
 
 .email-text {

--- a/mail-vue/src/views/email/index.vue
+++ b/mail-vue/src/views/email/index.vue
@@ -93,12 +93,12 @@ async function latest() {
         const curTimeSort = params.timeSort
         let list = []
 
-        //确保发起请求时最后一个邮件是当前账号的,或者
+        // Ensure the latest email belongs to the current account when the request is made
         if (accountId === scroll.value.latestEmail?.reqAccountId) {
           list = await emailLatest(latestId, accountId, allReceive);
         }
 
-        //确保请求回来后，账号没有切换，时间排序没有改变，全部邮件类型没变
+        // Ensure account, time sort, and email type have not changed after the request returns
         if (accountId === accountStore.currentAccountId && params.timeSort === curTimeSort && allReceive === accountStore.currentAccount.allReceive) {
           if (list.length > 0) {
 

--- a/mail-vue/src/views/login/index.vue
+++ b/mail-vue/src/views/login/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="login-box" :style=" background ? 'background: var(--el-bg-color)' : ''" v-loading="oauthLoading" element-loading-text="登录中...">
+  <div id="login-box" :style=" background ? 'background: var(--el-bg-color)' : ''" v-loading="oauthLoading" element-loading-text="Logging in...">
     <div id="background-wrap" v-if="!settingStore.settings.background">
       <div class="x1 cloud"></div>
       <div class="x2 cloud"></div>
@@ -106,7 +106,7 @@
         </template>
       </div>
     </div>
-    <el-dialog class="bind-dialog" v-model="showBindForm"  title="注册邮箱" >
+    <el-dialog class="bind-dialog" v-model="showBindForm"  title="Register Email" >
       <div class="bind-container">
         <el-input :class="!hideLoginDomain ? 'email-input' : ''" v-model="bindForm.email" type="text" :placeholder="$t('emailAccount')" autocomplete="off">
           <template #append v-if="!hideLoginDomain">
@@ -136,7 +136,7 @@
         <el-input v-if="settingStore.settings.regKey === 2" v-model="bindForm.code"
                   :placeholder="$t('regKeyOptional')" type="text" autocomplete="off"/>
         <el-button class="btn" type="primary" @click="bind" :loading="bindLoading"
-        >绑定
+        >Bind
         </el-button>
       </div>
     </el-dialog>
@@ -212,7 +212,7 @@ window.onTurnstileError = (e) => {
     return
   }
   verifyErrorCount++
-  console.warn('人机验加载失败', e)
+  console.warn('CAPTCHA failed to load', e)
   setTimeout(() => {
     nextTick(() => {
       if (!turnstileId) {
@@ -297,7 +297,7 @@ async function linuxDoGetUser() {
         showBindForm.value = true
         oauthLoading.value = false
         ElMessage({
-          message: '请注册绑定一个邮箱',
+          message: 'Please register and bind an email address',
           type: 'warning',
           duration: 4000,
           plain: true,
@@ -526,7 +526,7 @@ function submitRegister() {
             turnstileId = window.turnstile.render('.register-turnstile')
           } catch (e) {
             botJsError.value = true
-            console.log('人机验证js加载失败')
+            console.log('CAPTCHA script failed to load')
           }
         } else {
           window.turnstile.reset('.register-turnstile')

--- a/mail-vue/src/views/reg-key/index.vue
+++ b/mail-vue/src/views/reg-key/index.vue
@@ -267,9 +267,9 @@ async function copyCode(code) {
       plain: true,
     })
   } catch (err) {
-    console.error('复制失败:', err);
+    console.error('Copy failed:', err);
     ElMessage({
-      message: '复制失败',
+      message: 'Copy failed',
       type: 'error',
       plain: true,
     })

--- a/mail-vue/src/views/setting/index.vue
+++ b/mail-vue/src/views/setting/index.vue
@@ -2,6 +2,23 @@
   <div class="box">
     <div class="container">
       <div class="title">{{$t('profile')}}</div>
+      <div class="avatar-row">
+        <div class="avatar-preview" @click="triggerFileInput">
+          <img v-if="userStore.user.avatar" :src="userStore.user.avatar" class="avatar-img" alt="avatar"/>
+          <div v-else class="avatar-placeholder">{{ formatInitial(userStore.user.email) }}</div>
+          <div class="avatar-overlay">
+            <span>{{ $t('uploadAvatar') }}</span>
+          </div>
+        </div>
+        <div class="avatar-actions">
+          <div class="avatar-desc">{{ $t('avatarDesc') }}</div>
+          <div class="avatar-btns">
+            <el-button size="small" type="primary" :loading="avatarLoading" @click="triggerFileInput">{{ $t('uploadAvatar') }}</el-button>
+            <el-button size="small" v-if="userStore.user.avatar" :loading="avatarDelLoading" @click="confirmDeleteAvatar">{{ $t('deleteAvatar') }}</el-button>
+          </div>
+          <input ref="fileInputRef" type="file" accept="image/*" style="display:none" @change="onFileChange"/>
+        </div>
+      </div>
       <div class="item">
         <div>{{$t('username')}}</div>
         <div>
@@ -62,7 +79,7 @@
 </template>
 <script setup>
 import {reactive, ref, defineOptions} from 'vue'
-import {resetPassword, userDelete} from "@/request/my.js";
+import {resetPassword, userDelete, uploadAvatar, deleteAvatar} from "@/request/my.js";
 import {useUserStore} from "@/store/user.js";
 import router from "@/router/index.js";
 import {accountSetName} from "@/request/account.js";
@@ -78,6 +95,57 @@ const setPwdLoading = ref(false)
 const setNameShow = ref(false)
 const accountName = ref(null)
 const langSelect = ref(settingStore.lang)
+const avatarLoading = ref(false)
+const avatarDelLoading = ref(false)
+const fileInputRef = ref(null)
+
+function formatInitial(email) {
+  return email?.[0]?.toUpperCase() || ''
+}
+
+function triggerFileInput() {
+  fileInputRef.value?.click()
+}
+
+async function onFileChange(e) {
+  const file = e.target.files?.[0]
+  if (!file) return
+
+  if (!file.type.startsWith('image/')) {
+    ElMessage({ message: t('avatarTypeError'), type: 'error', plain: true })
+    return
+  }
+
+  if (file.size > 5 * 1024 * 1024) {
+    ElMessage({ message: t('avatarTooLarge'), type: 'error', plain: true })
+    return
+  }
+
+  avatarLoading.value = true
+  uploadAvatar(file).then(() => {
+    userStore.refreshUserInfo()
+    ElMessage({ message: t('avatarUploadSuccess'), type: 'success', plain: true })
+  }).finally(() => {
+    avatarLoading.value = false
+    e.target.value = ''
+  })
+}
+
+function confirmDeleteAvatar() {
+  ElMessageBox.confirm(t('deleteAvatarConfirm'), {
+    confirmButtonText: t('confirm'),
+    cancelButtonText: t('cancel'),
+    type: 'warning'
+  }).then(() => {
+    avatarDelLoading.value = true
+    deleteAvatar().then(() => {
+      userStore.refreshUserInfo()
+      ElMessage({ message: t('avatarDeleteSuccess'), type: 'success', plain: true })
+    }).finally(() => {
+      avatarDelLoading.value = false
+    })
+  })
+}
 
 defineOptions({
   name: 'setting'
@@ -229,6 +297,74 @@ function submitPwd() {
     display: grid;
     gap: 20px;
     margin-bottom: 40px;
+
+    .avatar-row {
+      display: flex;
+      align-items: center;
+      gap: 20px;
+
+      .avatar-preview {
+        position: relative;
+        width: 72px;
+        height: 72px;
+        border-radius: 14px;
+        overflow: hidden;
+        cursor: pointer;
+        border: 1px solid var(--dark-border);
+        flex-shrink: 0;
+
+        .avatar-img {
+          width: 100%;
+          height: 100%;
+          object-fit: cover;
+          display: block;
+        }
+
+        .avatar-placeholder {
+          width: 100%;
+          height: 100%;
+          background: var(--el-bg-color);
+          color: var(--el-text-color-primary);
+          font-size: 28px;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+
+        .avatar-overlay {
+          position: absolute;
+          inset: 0;
+          background: rgba(0, 0, 0, 0.45);
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          opacity: 0;
+          transition: opacity 0.2s;
+          color: #fff;
+          font-size: 12px;
+        }
+
+        &:hover .avatar-overlay {
+          opacity: 1;
+        }
+      }
+
+      .avatar-actions {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+
+        .avatar-desc {
+          font-size: 12px;
+          color: var(--regular-text-color);
+        }
+
+        .avatar-btns {
+          display: flex;
+          gap: 8px;
+        }
+      }
+    }
 
     .item {
       display: grid;

--- a/mail-vue/src/views/sys-setting/index.vue
+++ b/mail-vue/src/views/sys-setting/index.vue
@@ -1029,7 +1029,7 @@ function getUpdate() {
     setTimeout(() => {
       getUpdate()
     }, 2000)
-    console.error('检查更新失败：', e)
+    console.error('Update check failed:', e)
   })
 }
 

--- a/mail-vue/src/views/user/index.vue
+++ b/mail-vue/src/views/user/index.vue
@@ -229,9 +229,9 @@
       <div class="details">
         <div v-if="userDetails.username"><span class="details-item-title">LinuxDo:</span>
           <el-avatar :src="userDetails.avatar" :size="30" class="linuxdo-avatar"  />
-          <span style="margin: 0 10px">用户名：{{userDetails.username}}</span>
+          <span style="margin: 0 10px">Username: {{userDetails.username}}</span>
           <span>
-                    等级：<el-tag type="success">{{userDetails.trustLevel}}</el-tag>
+                    Trust Level: <el-tag type="success">{{userDetails.trustLevel}}</el-tag>
                   </span>
         </div>
         <div v-if="!sendNumShow"><span
@@ -1276,7 +1276,7 @@ function adjustWidth() {
 
 :deep(.el-table) {
   @media (pointer: coarse) {
-    /* 触屏 */
+    /* Touch screen */
     user-select: none;
   }
 }

--- a/mail-worker/src/api/my-api.js
+++ b/mail-worker/src/api/my-api.js
@@ -18,4 +18,14 @@ app.delete('/my/delete', async (c) => {
 	return c.json(result.ok());
 });
 
+app.put('/my/avatar', async (c) => {
+	await userService.uploadAvatar(c, userContext.getUserId(c));
+	return c.json(result.ok());
+});
+
+app.delete('/my/avatar', async (c) => {
+	await userService.deleteAvatar(c, userContext.getUserId(c));
+	return c.json(result.ok());
+});
+
 

--- a/mail-worker/src/api/r2-api.js
+++ b/mail-worker/src/api/r2-api.js
@@ -4,6 +4,9 @@ import app from '../hono/hono';
 app.get('/oss/*', async (c) => {
 	const key = c.req.path.split('/oss/')[1];
 	const obj = await r2Service.getObj(c, key);
+	if (obj instanceof Response) {
+		return obj;
+	}
 	return new Response(obj.body, {
 		headers: {
 			'Content-Type': obj.httpMetadata?.contentType || 'application/octet-stream',

--- a/mail-worker/src/email/email.js
+++ b/mail-worker/src/email/email.js
@@ -157,12 +157,12 @@ export async function email(message, env, ctx) {
 
 		}
 
-		//转发到TG
+		// Forward to Telegram
 		if (tgBotStatus === settingConst.tgBotStatus.OPEN && tgChatId) {
 			await telegramService.sendEmailToBot({ env }, emailRow)
 		}
 
-		//转发到其他邮箱
+		// Forward to other email addresses
 		if (forwardStatus === settingConst.forwardStatus.OPEN && forwardEmail) {
 
 			const emails = forwardEmail.split(',');
@@ -172,7 +172,7 @@ export async function email(message, env, ctx) {
 				try {
 					await message.forward(email);
 				} catch (e) {
-					console.error(`转发邮箱 ${email} 失败：`, e);
+					console.error(`Failed to forward to ${email}:`, e);
 				}
 
 			}));
@@ -180,7 +180,7 @@ export async function email(message, env, ctx) {
 		}
 
 	} catch (e) {
-		console.error('邮件接收异常: ', e);
+		console.error('Email receive error: ', e);
 		throw e
 	}
 }

--- a/mail-worker/src/entity/user.js
+++ b/mail-worker/src/entity/user.js
@@ -17,6 +17,7 @@ const user = sqliteTable('user', {
 	sort: text('sort').default(0),
 	sendCount: text('send_count').default(0),
 	regKeyId: integer('reg_key_id').default(0).notNull(),
-	isDel: integer('is_del').default(0).notNull()
+	isDel: integer('is_del').default(0).notNull(),
+	avatar: text('avatar')
 });
 export default user

--- a/mail-worker/src/hono/hono.js
+++ b/mail-worker/src/hono/hono.js
@@ -14,15 +14,15 @@ app.onError((err, c) => {
 	}
 
 	if (err.message === `Cannot read properties of undefined (reading 'get')`) {
-		return c.json(result.fail('KV数据库未绑定 KV database not bound',502));
+		return c.json(result.fail('KV database not bound',502));
 	}
 
 	if (err.message === `Cannot read properties of undefined (reading 'put')`) {
-		return c.json(result.fail('KV数据库未绑定 KV database not bound',502));
+		return c.json(result.fail('KV database not bound',502));
 	}
 
 	if (err.message === `Cannot read properties of undefined (reading 'prepare')`) {
-		return c.json(result.fail('D1数据库未绑定 D1 database not bound',502));
+		return c.json(result.fail('D1 database not bound',502));
 	}
 
 	return c.json(result.fail(err.message, err.code));

--- a/mail-worker/src/hono/hono.js
+++ b/mail-worker/src/hono/hono.js
@@ -13,16 +13,30 @@ app.onError((err, c) => {
 		console.error(err);
 	}
 
-	if (err.message === `Cannot read properties of undefined (reading 'get')`) {
-		return c.json(result.fail('KV database not bound',502));
+	if (
+		err.message === `Cannot read properties of undefined (reading 'get')` ||
+		err.message === `Cannot read properties of null (reading 'get')` ||
+		err.message === `c.env.kv.get is not a function` ||
+		(err.message && err.message.includes('kv') && err.message.includes('not a function'))
+	) {
+		return c.json(result.fail('KV database not bound', 502));
 	}
 
-	if (err.message === `Cannot read properties of undefined (reading 'put')`) {
-		return c.json(result.fail('KV database not bound',502));
+	if (
+		err.message === `Cannot read properties of undefined (reading 'put')` ||
+		err.message === `Cannot read properties of null (reading 'put')` ||
+		err.message === `c.env.kv.put is not a function` ||
+		(err.message && err.message.includes('kv') && err.message.includes('not a function'))
+	) {
+		return c.json(result.fail('KV database not bound', 502));
 	}
 
-	if (err.message === `Cannot read properties of undefined (reading 'prepare')`) {
-		return c.json(result.fail('D1 database not bound',502));
+	if (
+		err.message === `Cannot read properties of undefined (reading 'prepare')` ||
+		err.message === `Cannot read properties of null (reading 'prepare')` ||
+		(err.message && err.message.includes('db') && err.message.includes('not a function'))
+	) {
+		return c.json(result.fail('D1 database not bound', 502));
 	}
 
 	return c.json(result.fail(err.message, err.code));

--- a/mail-worker/src/i18n/en.js
+++ b/mail-worker/src/i18n/en.js
@@ -66,6 +66,9 @@ const en = {
 	notAdmin: 'The entered email is not an administrator email',
 	emailExistDatabase: 'Email already exists in the database',
 	notConfigOss: 'Object storage not configured',
+	noOsUpAvatar: 'Cannot upload avatar: object storage not configured',
+	avatarTypeError: 'Only image files are supported',
+	avatarTooLarge: 'Avatar file size cannot exceed 5MB',
 	perms: {
 		"邮件": "Emails",
 		"邮件发送": "Send Email",

--- a/mail-worker/src/i18n/zh.js
+++ b/mail-worker/src/i18n/zh.js
@@ -66,6 +66,9 @@ const zh = {
 	notAdmin: '输入的邮箱不是管理员邮箱',
 	emailExistDatabase: '有邮箱已存在数据库中',
 	notConfigOss: '对象存储未配置',
+	noOsUpAvatar: '对象存储未配置不能上传头像',
+	avatarTypeError: '只支持图片文件',
+	avatarTooLarge: '头像文件大小不能超过5MB',
 	perms: {
 		"邮件": "邮件",
 		"邮件发送": "邮件发送",

--- a/mail-worker/src/init/init.js
+++ b/mail-worker/src/init/init.js
@@ -38,7 +38,7 @@ const dbInit = {
 		try {
 			await c.env.db.prepare(`ALTER TABLE setting ADD COLUMN login_darken_factor INTEGER NOT NULL DEFAULT 0;`).run();
 		} catch (e) {
-			console.warn(`跳过字段：${e.message}`);
+			console.warn(`Skipping field: ${e.message}`);
 		}
 	},
 
@@ -50,7 +50,7 @@ const dbInit = {
 				await c.env.db.prepare(`ALTER TABLE setting ADD COLUMN ai_code_filter TEXT NOT NULL DEFAULT '';`)
 			]);
 		} catch (e) {
-			console.warn(`跳过字段：${e.message}`);
+			console.warn(`Skipping field: ${e.message}`);
 		}
 
 		try {
@@ -60,7 +60,7 @@ const dbInit = {
 				c.env.db.prepare(`ALTER TABLE setting ADD COLUMN black_from TEXT NOT NULL DEFAULT '';`)
 			]);
 		} catch (e) {
-			console.warn(`跳过字段：${e.message}`);
+			console.warn(`Skipping field: ${e.message}`);
 		}
 
 	},
@@ -69,7 +69,7 @@ const dbInit = {
 		try {
 			await c.env.db.prepare(`UPDATE setting SET auto_refresh = 5 WHERE auto_refresh = 1;`).run();
 		} catch (e) {
-			console.warn(`跳过字段：${e.message}`);
+			console.warn(`Skipping field: ${e.message}`);
 		}
 	},
 
@@ -79,7 +79,7 @@ const dbInit = {
 				c.env.db.prepare(`ALTER TABLE account ADD COLUMN sort INTEGER NOT NULL DEFAULT 0;`)
 			]);
 		} catch (e) {
-			console.warn(`跳过字段：${e.message}`);
+			console.warn(`Skipping field: ${e.message}`);
 		}
 	},
 
@@ -89,7 +89,7 @@ const dbInit = {
 				c.env.db.prepare(`ALTER TABLE setting RENAME COLUMN auto_refresh_time TO auto_refresh;`)
 			]);
 		} catch (e) {
-			console.warn(`跳过字段：${e.message}`);
+			console.warn(`Skipping field: ${e.message}`);
 		}
 	},
 
@@ -97,7 +97,7 @@ const dbInit = {
 		try {
 			await c.env.db.prepare(`ALTER TABLE account ADD COLUMN all_receive INTEGER NOT NULL DEFAULT 0;`).run();
 		} catch (e) {
-			console.warn(`跳过字段：${e.message}`);
+			console.warn(`Skipping field: ${e.message}`);
 		}
 	},
 
@@ -106,7 +106,7 @@ const dbInit = {
 		try {
 			await c.env.db.prepare(`ALTER TABLE setting ADD COLUMN email_prefix_filter text NOT NULL DEFAULT '';`).run();
 		} catch (e) {
-			console.warn(`跳过字段：${e.message}`);
+			console.warn(`Skipping field: ${e.message}`);
 		}
 
 		try {
@@ -115,7 +115,7 @@ const dbInit = {
 				c.env.db.prepare(`UPDATE email SET unread = 1;`)
 			]);
 		} catch (e) {
-			console.warn(`跳过字段：${e.message}`);
+			console.warn(`Skipping field: ${e.message}`);
 		}
 
 	},
@@ -138,13 +138,13 @@ const dbInit = {
 				)
 			`).run();
 		} catch (e) {
-			console.warn(`跳过字段：${e.message}`);
+			console.warn(`Skipping field: ${e.message}`);
 		}
 
 		try {
 			await c.env.db.prepare(`ALTER TABLE setting ADD COLUMN min_email_prefix INTEGER NOT NULL DEFAULT 1;`).run();
 		} catch (e) {
-			console.warn(`跳过字段：${e.message}`);
+			console.warn(`Skipping field: ${e.message}`);
 		}
 
 	},
@@ -158,13 +158,13 @@ const dbInit = {
 				c.env.db.prepare(`ALTER TABLE setting ADD COLUMN tg_msg_from TEXT NOT NULL DEFAULT 'only-name';`)
 			]);
 		} catch (e) {
-			console.warn(`跳过字段：${e.message}`);
+			console.warn(`Skipping field: ${e.message}`);
 		}
 
 		try {
 			await c.env.db.prepare(`ALTER TABLE setting ADD COLUMN tg_msg_text TEXT NOT NULL DEFAULT 'show';`).run();
 		} catch (e) {
-			console.warn(`跳过字段：${e.message}`);
+			console.warn(`Skipping field: ${e.message}`);
 		}
 
 	},
@@ -180,7 +180,7 @@ const dbInit = {
 				c.env.db.prepare(`DELETE FROM perm WHERE perm_key = 'setting:clean'`)
 			]);
 		} catch (e) {
-			console.warn(`跳过字段：${e.message}`);
+			console.warn(`Skipping field: ${e.message}`);
 		}
 	},
 
@@ -188,15 +188,15 @@ const dbInit = {
 		try {
 			await c.env.db.prepare(`ALTER TABLE setting ADD COLUMN login_domain INTEGER NOT NULL DEFAULT 0;`).run();
 		} catch (e) {
-			console.warn(`跳过字段：${e.message}`);
+			console.warn(`Skipping field: ${e.message}`);
 		}
 	},
 
 	async v1_6DB(c) {
 
-		const noticeContent = '本项目仅供学习交流，禁止用于违法业务\n' +
+		const noticeContent = 'This project is for learning and communication only. Use for illegal purposes is prohibited.\n' +
 			'<br>\n' +
-			'请遵守当地法规，作者不承担任何法律责任'
+			'Please comply with local laws. The author assumes no legal responsibility.'
 
 		const ADD_COLUMN_SQL_LIST = [
 			`ALTER TABLE setting ADD COLUMN reg_verify_count INTEGER NOT NULL DEFAULT 1;`,
@@ -225,7 +225,7 @@ const dbInit = {
 			try {
 				await c.env.db.prepare(sql).run();
 			} catch (e) {
-				console.warn(`跳过字段：${e.message}`);
+				console.warn(`Skipping field: ${e.message}`);
 			}
 		});
 
@@ -250,7 +250,7 @@ const dbInit = {
 		try {
 			await c.env.db.prepare(`ALTER TABLE role ADD COLUMN avail_domain TEXT NOT NULL DEFAULT ''`).run();
 		} catch (e) {
-			console.warn(`跳过字段添加：${e.message}`);
+			console.warn(`Skipping field addition: ${e.message}`);
 		}
 	},
 
@@ -267,13 +267,13 @@ const dbInit = {
       )
     `).run();
 
-		// 添加不区分大小写的唯一索引
+		// Add case-insensitive unique index
 		try {
 			await c.env.db.prepare(`
 				CREATE UNIQUE INDEX IF NOT EXISTS idx_setting_code ON reg_key(code COLLATE NOCASE)
 			`).run();
 		} catch (e) {
-			console.warn(`跳过创建索引：${e.message}`);
+			console.warn(`Skipping index creation: ${e.message}`);
 		}
 
 
@@ -285,7 +285,7 @@ const dbInit = {
         (35,'密钥添加', 'reg-key:add', 33, 2, 1),
         (36,'密钥删除', 'reg-key:delete', 33, 2, 2)`).run();
 		} catch (e) {
-			console.warn(`跳过数据：${e.message}`);
+			console.warn(`Skipping data insert: ${e.message}`);
 		}
 
 		const ADD_COLUMN_SQL_LIST = [
@@ -299,7 +299,7 @@ const dbInit = {
 			try {
 				await c.env.db.prepare(sql).run();
 			} catch (e) {
-				console.warn(`跳过字段添加：${e.message}`);
+				console.warn(`Skipping field addition: ${e.message}`);
 			}
 		});
 
@@ -327,7 +327,7 @@ const dbInit = {
 			try {
 				await c.env.db.prepare(sql).run();
 			} catch (e) {
-				console.warn(`跳过字段添加：${e.message}`);
+				console.warn(`Skipping field addition: ${e.message}`);
 			}
 		});
 
@@ -364,7 +364,7 @@ const dbInit = {
 			try {
 				await c.env.db.prepare(sql).run();
 			} catch (e) {
-				console.warn(`跳过字段添加：${e.message}`);
+				console.warn(`Skipping field addition: ${e.message}`);
 			}
 		});
 
@@ -379,13 +379,13 @@ const dbInit = {
         (31,'分析页', NULL, 0, 1, 2.1),
         (32,'数据查看', 'analysis:query', 31, 2, 1)`).run();
 		} catch (e) {
-			console.warn(`跳过数据：${e.message}`);
+			console.warn(`Skipping data insert: ${e.message}`);
 		}
 
 	},
 
 	async v1_1DB(c) {
-		// 添加字段
+		// Add fields
 		const ADD_COLUMN_SQL_LIST = [
 			`ALTER TABLE email ADD COLUMN type INTEGER NOT NULL DEFAULT 0;`,
 			`ALTER TABLE email ADD COLUMN status INTEGER NOT NULL DEFAULT 0;`,
@@ -416,13 +416,13 @@ const dbInit = {
 			try {
 				await c.env.db.prepare(sql).run();
 			} catch (e) {
-				console.warn(`跳过字段添加：${e.message}`);
+				console.warn(`Skipping field addition: ${e.message}`);
 			}
 		});
 
 		await Promise.all(promises);
 
-		// 创建 perm 表并初始化
+		// Create perm table and initialize
 		await c.env.db.prepare(`
       CREATE TABLE IF NOT EXISTS perm (
         perm_id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -473,7 +473,7 @@ const dbInit = {
 
 		await c.env.db.prepare(`UPDATE perm SET perm_key = 'setting:clean' WHERE perm_key = 'seting:clear'`).run();
 		await c.env.db.prepare(`DELETE FROM perm WHERE perm_key = 'user:star'`).run();
-		// 创建 role 表并插入默认身份
+		// Create role table and insert default role
 		await c.env.db.prepare(`
       CREATE TABLE IF NOT EXISTS role (
         role_id INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
@@ -496,12 +496,12 @@ const dbInit = {
         INSERT INTO role (
           role_id, name, key, create_time, sort, description, user_id, is_default, send_count, send_type, account_count
         ) VALUES (
-          1, '普通用户', NULL, '0000-00-00 00:00:00', 0, '只有普通使用权限', 0, 1, NULL, 'ban', 10
+          1, 'Regular User', NULL, '0000-00-00 00:00:00', 0, 'Basic usage permissions only', 0, 1, NULL, 'ban', 10
         )
       `).run();
 		}
 
-		// 创建 role_perm 表并初始化数据
+		// Create role_perm table and initialize data
 		await c.env.db.prepare(`
       CREATE TABLE IF NOT EXISTS role_perm (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -528,7 +528,7 @@ const dbInit = {
 	},
 
 	async intDB(c) {
-		// 初始化数据库表结构
+		// Initialize database schema
 		await c.env.db.prepare(`
 		  CREATE TABLE IF NOT EXISTS email (
 			email_id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,

--- a/mail-worker/src/init/init.js
+++ b/mail-worker/src/init/init.js
@@ -40,6 +40,10 @@ const dbInit = {
 		} catch (e) {
 			console.warn(`Skipping field: ${e.message}`);
 		}
+
+		const oldChineseNotice = '本项目仅供学习交流，禁止用于违法业务\n<br>\n请遵守当地法规，作者不承担任何法律责任';
+		const englishNotice = 'This project is for learning and communication only. Use for illegal purposes is prohibited.\n<br>\nPlease comply with local laws. The author assumes no legal responsibility.';
+		await c.env.db.prepare(`UPDATE setting SET notice_content = ? WHERE notice_content = ?;`).bind(englishNotice, oldChineseNotice).run();
 	},
 
 	async v3_0DB(c) {

--- a/mail-worker/src/init/init.js
+++ b/mail-worker/src/init/init.js
@@ -30,8 +30,17 @@ const dbInit = {
 		await this.v2_9DB(c);
 		await this.v3_0DB(c);
 		await this.v3_1DB(c);
+		await this.v3_2DB(c);
 		await settingService.refresh(c);
 		return c.text('success');
+	},
+
+	async v3_2DB(c) {
+		try {
+			await c.env.db.prepare(`ALTER TABLE user ADD COLUMN avatar TEXT;`).run();
+		} catch (e) {
+			console.warn(`Skipping field: ${e.message}`);
+		}
 	},
 
 	async v3_1DB(c) {

--- a/mail-worker/src/service/ai-service.js
+++ b/mail-worker/src/service/ai-service.js
@@ -46,7 +46,7 @@ const aiService = {
 
 			return json.code;
 		} catch (e) {
-			console.error('验证码提取失败: ', e);
+			console.error('Verification code extraction failed: ', e);
 			return '';
 		}
 	},

--- a/mail-worker/src/service/analysis-service.js
+++ b/mail-worker/src/service/analysis-service.js
@@ -52,7 +52,7 @@ const analysisService = {
 
 		localDate = dayjs(localDate.format('YYYY-MM-DD HH:mm:ss'))
 
-		//获取时差
+		// Get time difference
 		const diffHours = localDate.diff(utcDate, 'hour',true);
 
 

--- a/mail-worker/src/service/att-service.js
+++ b/mail-worker/src/service/att-service.js
@@ -59,7 +59,7 @@ const attService = {
 
 		for (const img of images) {
 
-			//邮件正文base64图片转cid附件
+			// Convert base64 inline image to cid attachment
 			const src = img.getAttribute('src');
 			if (src && src.startsWith('data:image')) {
 				const file = fileUtils.base64ToFile(src);
@@ -81,7 +81,7 @@ const attService = {
 				imageDataList.push(attData);
 			}
 
-			//邮件正文站内图片转cid附件
+			// Convert hosted inline image to cid attachment
 			if (src && (src.startsWith(domainUtils.toOssDomain(r2Domain)) || src.startsWith('attachments/'))) {
 
 				const cid = uuidv4().replace(/-/g, '')
@@ -113,11 +113,11 @@ const attService = {
 			}
 		}
 
-		//查询已有内嵌url图片信息
+		// Query existing embedded image info
 		const keys = [...new Set(imageDataList.filter(item => !item.content).map(item => item.key))];
 		const dbImageList  = await this.selectOneByKeys(c, keys);
 
-		//设置给当前附件
+		// Assign to current attachment
 		await Promise.all(imageDataList.map(async image => {
 			if (image.content) {
 				return;

--- a/mail-worker/src/service/email-service.js
+++ b/mail-worker/src/service/email-service.js
@@ -149,26 +149,26 @@ const emailService = {
 		return orm(c).insert(email).values({ ...params }).returning().get();
 	},
 
-	//邮件发送
+	// Send email
 	async send(c, params, userId) {
 
 		let {
-			accountId, //发送账号id
-			name, //发件人名字
-			sendType, //发件类型
-			emailId, //邮件id，如果是回复邮件会带
-			receiveEmail, //收件人邮箱
-			text, //邮件纯文本
-			content, //邮件内容
-			subject, //邮件标题
-			attachments = [] //附件
+			accountId, // sender account id
+			name, // sender name
+			sendType, // send type
+			emailId, // email id, present when replying to an email
+			receiveEmail, // recipient email
+			text, // plain text body
+			content, // html content
+			subject, // email subject
+			attachments = [] // attachments
 		} = params;
 
 		const { resendTokens, r2Domain, send, domainList } = await settingService.query(c);
 
 		let { imageDataList, html } = await attService.toImageUrlHtml(c, content);
 
-		//判断是否关闭发件功能
+		// Check if sending is disabled
 		if (send === settingConst.send.CLOSE) {
 			throw new BizError(t('disabledSend'), 403);
 		}
@@ -176,7 +176,7 @@ const emailService = {
 		const userRow = await userService.selectById(c, userId);
 		const roleRow = await roleService.selectById(c, userRow.type);
 
-		//判断接收方是不是全部为站内邮箱
+		// Check if all recipients are internal mailboxes
 		const allInternal = receiveEmail.every(email => {
 			const domain = '@' + emailUtils.getDomain(email);
 			return domainList.includes(domain);
@@ -184,19 +184,19 @@ const emailService = {
 
 		if (c.env.admin !== userRow.email) {
 
-			//发件被禁用
+			// Sending is disabled
 			if (roleRow.sendType === 'ban') {
 				throw new BizError(t('bannedSend'), 403);
 			}
 
-			//发件被禁用
+			// Sending is disabled
 			if (roleRow.sendType === 'internal' && !allInternal) {
 				throw new BizError(t('onlyInternalSend'), 403);
 			}
 
 		}
 
-		//如果不是管理员，权限设置了发送次数
+		// If not admin, check role send count limit
 		if (c.env.admin !== userRow.email && roleRow.sendCount) {
 
 			if (userRow.sendCount >= roleRow.sendCount) {
@@ -222,7 +222,7 @@ const emailService = {
 		}
 
 		if (c.env.admin !== userRow.email) {
-			//用户没有这个域名的使用权限
+			// User does not have permission for this domain
 			if(!roleService.hasAvailDomainPerm(roleRow.availDomain, accountRow.email)) {
 				throw new BizError(t('noDomainPermSend'),403)
 			}
@@ -233,12 +233,12 @@ const emailService = {
 		const resendToken = resendTokens[domain];
 		const useCloudflareEmail = !!c.env.email;
 
-		//如果接收方存在站外邮箱，又没有发信服务
+		// External recipient exists but no email sending service configured
 		if (!useCloudflareEmail && !resendToken && !allInternal) {
 			throw new BizError(t('noSendProvider'));
 		}
 
-		//没有发件人名字自动截取
+		// Auto-extract sender name if not provided
 		if (!name) {
 			name = emailUtils.getName(accountRow.email);
 		}
@@ -247,7 +247,7 @@ const emailService = {
 			messageId: null
 		};
 
-		//如果是回复邮件
+		// If this is a reply email
 		if (sendType === 'reply') {
 
 			emailRow = await this.selectById(c, emailId);
@@ -260,7 +260,7 @@ const emailService = {
 
 		let sendResult = {};
 
-		//存在站外邮箱时，如果配置了 Cloudflare Email Service 就优先使用，否则使用 Resend
+		// Use Cloudflare Email Service if configured, otherwise use Resend
 		if (!allInternal) {
 
 			if (useCloudflareEmail) {
@@ -300,10 +300,10 @@ const emailService = {
 
 		imageDataList = imageDataList.map(item => ({...item, contentId: `<${item.contentId}>`}))
 
-		//把图片标签cid标签切换会通用url
+		// Convert cid image tags back to regular URLs
 		html = this.imgReplace(html, imageDataList, r2Domain);
 
-		//封装数据保存到数据库
+		// Prepare and save data to database
 		const emailData = {};
 		emailData.sendEmail = accountRow.email;
 		emailData.name = name;
@@ -329,15 +329,15 @@ const emailService = {
 			emailData.relation = emailRow.messageId;
 		}
 
-		//如果权限有发送次数增加用户发送次数
+		// Increment send count if role has send count limit
 		if (roleRow.sendCount && roleRow.sendType !== 'internal') {
 			await userService.incrUserSendCount(c, receiveEmail.length, userId);
 		}
 
-		//保存到数据库并返回结果
+		// Save to database and return result
 		const emailResult = await orm(c).insert(email).values(emailData).returning().get();
 
-		//保存内嵌附件
+		// Save inline attachments
 		if (imageDataList.length > 0) {
 			if (imageDataList.length > 10) {
 				throw new BizError(t('imageAttLimit'));
@@ -345,7 +345,7 @@ const emailService = {
 			await attService.saveArticleAtt(c, imageDataList, userId, accountId, emailResult.emailId);
 		}
 
-		//保存普通附件
+		// Save regular attachments
 		if (attachments?.length > 0) {
 			if (attachments.length > 10) {
 				throw new BizError(t('attLimit'));
@@ -356,7 +356,7 @@ const emailService = {
 		const attList = await attService.selectByEmailIds(c, [emailResult.emailId]);
 		emailResult.attList = attList;
 
-		//如果全是站内接收方，直接写入数据库
+		// All internal recipients: write directly to database
 		if (allInternal) {
 			await this.HandleOnSiteEmail(c, receiveEmail, emailResult, attList);
 		}
@@ -364,7 +364,7 @@ const emailService = {
 		const dateStr = dayjs().format('YYYY-MM-DD');
 		let daySendTotal = await c.env.kv.get(kvConst.SEND_DAY_COUNT + dateStr);
 
-		//记录每天发件次数统计
+		// Record daily send count statistics
 		if (!daySendTotal) {
 			await c.env.kv.put(kvConst.SEND_DAY_COUNT + dateStr, JSON.stringify(receiveEmail.length), { expirationTtl: 60 * 60 * 24 });
 		} else  {
@@ -540,24 +540,24 @@ const emailService = {
 		return content;
 	},
 
-	//处理站内邮件发送
+	// Handle internal email delivery
 	async HandleOnSiteEmail(c, receiveEmail, sendEmailData, attList) {
 
 		const { noRecipient  } = await settingService.query(c);
 
-		//查询所有收件人账号信息
+		// Query all recipient account info
 		let accountList = await orm(c).select().from(account).where(inArray(account.email, receiveEmail)).all();
 
-		//查询所有收件人权限身份
+		// Query all recipient role permissions
 		const userIds = accountList.map(accountRow => accountRow.userId);
 		let roleList = await roleService.selectByUserIds(c, userIds);
 
-		//封装数据库准备保存到数据库
+		// Prepare database data for saving
 		const emailDataList = [];
 
 		for (const email of receiveEmail) {
 
-			//把发件人邮件改成收件
+			// Set email as received for sender
 			const emailValues = {...sendEmailData}
 			emailValues.status = emailConst.status.RECEIVE;
 			emailValues.type = emailConst.type.RECEIVE;
@@ -567,10 +567,10 @@ const emailService = {
 
 			const accountRow = accountList.find(accountRow => accountRow.email === email);
 
-			//如果收件人存在就把邮件信息改成收件人的
+			// Update email info for existing recipient
 			if (accountRow) {
 
-				//设置给收件人保存
+				// Set data for recipient and save
 				emailValues.userId = accountRow.userId;
 				emailValues.accountId = accountRow.accountId;
 				emailValues.type = emailConst.type.RECEIVE;
@@ -580,7 +580,7 @@ const emailService = {
 
 				let { banEmail, availDomain } = roleRow;
 
-				//如果收件人没有这个域名的使用权限和有邮件拦截，就把邮件改为拒收状态
+				// Set email to rejected if recipient has no domain permission or email blocked
 				if (email !== c.env.admin) {
 
 					if (!roleService.hasAvailDomainPerm(availDomain, email)) {
@@ -597,13 +597,13 @@ const emailService = {
 
 			} else {
 
-				//设置无收件人邮件信息
+				// Set email info when there is no recipient
 				emailValues.userId = 0;
 				emailValues.accountId = 0;
 				emailValues.type = emailConst.type.RECEIVE;
 				emailValues.status = emailConst.status.NOONE;
 
-				//如果无人收件关闭改为拒收
+				// Set to rejected if no-recipient mode is disabled
 				if (noRecipient === settingConst.noRecipient.CLOSE) {
 					emailValues.status = emailConst.status.BOUNCED;
 					emailValues.message = `Recipient not found: <${email}>`;
@@ -615,14 +615,14 @@ const emailService = {
 
 		}
 
-		//保存邮件
+		// Save email
 		const receiveEmailList = emailDataList.filter(emailRow => emailRow.status === emailConst.status.RECEIVE || emailRow.status === emailConst.status.NOONE);
 
 		for (const emailData of receiveEmailList) {
 
 			const emailRow = await orm(c).insert(email).values(emailData).returning().get();
 
-			//设置附件保存
+			// Set and save attachments
 			for (const attRow of attList) {
 				const attValues = {...attRow};
 				attValues.emailId = emailRow.emailId;
@@ -639,7 +639,7 @@ const emailService = {
 
 		let status = emailConst.status.DELIVERED;
 		let message = ''
-		//如果有拒收邮件，就把发件人的邮件改成拒收
+		// If any rejected emails, update sender's email to rejected
 		if (bouncedEmail) {
 			const messageJson = { message: bouncedEmail.message };
 			message = JSON.stringify(messageJson);

--- a/mail-worker/src/service/oauth-service.js
+++ b/mail-worker/src/service/oauth-service.js
@@ -17,7 +17,7 @@ const oauthService = {
 		let userRow = await userService.selectByIdIncludeDel(c, oauthRow.userId);
 
 		if (userRow) {
-			throw new BizError('用户已绑定有邮箱')
+			throw new BizError('User already has a bound email')
 		}
 
 		await loginService.register(c, { email, password: cryptoUtils.genRandomPwd(), code }, true);
@@ -109,7 +109,7 @@ const oauthService = {
 		await orm(c).delete(oauth).where(inArray(oauth.userId, userIds)).run();
 	},
 
-	//定时任务凌晨清除未绑定邮箱的oauth用户
+	// Scheduled task: clear unbound oauth users at midnight
 	async clearNoBindOathUser(c) {
 		await orm(c).delete(oauth).where(eq(oauth.userId, 0)).run();
 	},

--- a/mail-worker/src/service/resend-service.js
+++ b/mail-worker/src/service/resend-service.js
@@ -41,7 +41,7 @@ const resendService = {
 		const emailRow = await emailService.updateEmailStatus(c, params)
 
 		if (!emailRow) {
-			throw new BizError('更新邮件状态记录失败');
+			throw new BizError('Failed to update email status record');
 		}
 
 	}

--- a/mail-worker/src/service/s3-service.js
+++ b/mail-worker/src/service/s3-service.js
@@ -48,11 +48,11 @@ const s3Service = {
 
 				const body = args.request.body
 
-				// 计算 MD5 校验和并转换为 Base64 编码
+				// Calculate MD5 checksum and encode as Base64
 				const encoder = new TextEncoder();
 				const data = encoder.encode(body);
 
-				// 使用 Web Crypto API 计算 MD5 校验和
+				// Use Web Crypto API to compute MD5 checksum
 				const hashBuffer = await crypto.subtle.digest('MD5', data);
 				const hashArray = new Uint8Array(hashBuffer);
 				const contentMD5 = btoa(String.fromCharCode.apply(null, hashArray));

--- a/mail-worker/src/service/setting-service.js
+++ b/mail-worker/src/service/setting-service.js
@@ -28,7 +28,7 @@ const settingService = {
 		const setting = await c.env.kv.get(KvConst.SETTING, { type: 'json' });
 
 		if (!setting) {
-			throw new BizError('数据库未初始化 Database not initialized.');
+			throw new BizError('Database not initialized.');
 		}
 
 		let domainList = c.env.domain;

--- a/mail-worker/src/service/telegram-service.js
+++ b/mail-worker/src/service/telegram-service.js
@@ -55,7 +55,7 @@ const telegramService = {
 		const inlineKeyboard = [
 			[
 				{
-					text: '查看',
+					text: 'View',
 					web_app: { url: webAppUrl }
 				}
 			]
@@ -87,10 +87,10 @@ const telegramService = {
 					})
 				});
 				if (!res.ok) {
-					console.error(`转发 Telegram 失败 status: ${res.status} response: ${await res.text()}`);
+					console.error(`Failed to forward to Telegram, status: ${res.status} response: ${await res.text()}`);
 				}
 			} catch (e) {
-				console.error(`转发 Telegram 失败:`, e.message);
+				console.error(`Failed to forward to Telegram:`, e.message);
 			}
 		}));
 

--- a/mail-worker/src/service/user-service.js
+++ b/mail-worker/src/service/user-service.js
@@ -3,6 +3,7 @@ import accountService from './account-service';
 import orm from '../entity/orm';
 import user from '../entity/user';
 import { and, asc, count, desc, eq, inArray, sql } from 'drizzle-orm';
+import r2Service from './r2-service';
 import { emailConst, isDel, roleConst, userConst } from '../const/entity-const';
 import kvConst from '../const/kv-const';
 import KvConst from '../const/kv-const';
@@ -29,10 +30,11 @@ const userService = {
 			throw new BizError(t('authExpired'), 401);
 		}
 
-		const [account, roleRow, permKeys] = await Promise.all([
+		const [account, roleRow, permKeys, oauthRow] = await Promise.all([
 			accountService.selectByEmailIncludeDel(c, userRow.email),
 			roleService.selectById(c, userRow.type),
-			userRow.email === c.env.admin ? Promise.resolve(['*']) : permService.userPermKeys(c, userId)
+			userRow.email === c.env.admin ? Promise.resolve(['*']) : permService.userPermKeys(c, userId),
+			orm(c).select({ avatar: oauth.avatar }).from(oauth).where(eq(oauth.userId, userId)).get()
 		]);
 
 		const user = {};
@@ -44,6 +46,7 @@ const userService = {
 		user.permKeys = permKeys;
 		user.role = roleRow;
 		user.type = userRow.type;
+		user.avatar = userRow.avatar ? `/oss/${userRow.avatar}` : (oauthRow?.avatar || null);
 
 		if (c.env.admin === userRow.email) {
 			user.role = constant.ADMIN_ROLE
@@ -364,6 +367,35 @@ const userService = {
 			await accountService.restoreByUserId(c, userId);
 		}
 
+	},
+
+	async uploadAvatar(c, userId) {
+		const storageType = await r2Service.storageType(c);
+		if (storageType === 'KV') {
+			throw new BizError(t('noOsUpAvatar'));
+		}
+
+		const formData = await c.req.formData();
+		const file = formData.get('file');
+
+		if (!file || !file.type.startsWith('image/')) {
+			throw new BizError(t('avatarTypeError'));
+		}
+
+		if (file.size > 5 * 1024 * 1024) {
+			throw new BizError(t('avatarTooLarge'));
+		}
+
+		const key = `avatar/${userId}`;
+		const buffer = await file.arrayBuffer();
+		await r2Service.putObj(c, key, buffer, { contentType: file.type });
+		await orm(c).update(user).set({ avatar: key }).where(eq(user.userId, userId)).run();
+	},
+
+	async deleteAvatar(c, userId) {
+		const key = `avatar/${userId}`;
+		await r2Service.delete(c, key);
+		await orm(c).update(user).set({ avatar: null }).where(eq(user.userId, userId)).run();
 	},
 
 	listByRegKeyId(c, regKeyId) {

--- a/mail-worker/src/service/user-service.js
+++ b/mail-worker/src/service/user-service.js
@@ -370,11 +370,6 @@ const userService = {
 	},
 
 	async uploadAvatar(c, userId) {
-		const storageType = await r2Service.storageType(c);
-		if (storageType === 'KV') {
-			throw new BizError(t('noOsUpAvatar'));
-		}
-
 		const formData = await c.req.formData();
 		const file = formData.get('file');
 

--- a/mail-worker/src/template/email-html.js
+++ b/mail-worker/src/template/email-html.js
@@ -25,7 +25,7 @@ export default function emailHtmlTemplate(html, domain) {
         		padding: 15px 10px;
             width: 100%;
             height: 100%;
-            overflow: auto; /* 改为 auto 允许滚动 */
+            overflow: auto;
             font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
         }
 
@@ -46,15 +46,15 @@ export default function emailHtmlTemplate(html, domain) {
             const container = document.getElementById('container');
             const shadowRoot = container.attachShadow({ mode: 'open' });
 
-            // 提取 <body> 的 style 属性
+            // Extract <body> style attribute
             const bodyStyleRegex = /<body[^>]*style="([^"]*)"[^>]*>/i;
             const bodyStyleMatch = html.match(bodyStyleRegex);
             const bodyStyle = bodyStyleMatch ? bodyStyleMatch[1] : '';
 
-            // 移除 <body> 标签
+            // Remove <body> tags
             const cleanedHtml = html.replace(/<\\/?body[^>]*>/gi, '');
 
-            // 渲染内容
+            // Render content
             shadowRoot.innerHTML = \`
                 <style>
                     :host {
@@ -67,7 +67,7 @@ export default function emailHtmlTemplate(html, domain) {
                         line-height: 1.5;
                         color: #13181D;
                         word-break: break-word;
-                        overflow: auto; /* 添加滚动 */
+                        overflow: auto;
                     }
 
                     h1, h2, h3, h4 {
@@ -89,7 +89,7 @@ export default function emailHtmlTemplate(html, domain) {
                         width: fit-content;
                         height: fit-content;
                         min-width: 100%;
-                        \${bodyStyle ? bodyStyle : ''} /* 注入 body 的 style */
+                        \${bodyStyle ? bodyStyle : ''}
                     }
 
                     img:not(table img) {
@@ -102,7 +102,7 @@ export default function emailHtmlTemplate(html, domain) {
                 </div>
             \`;
 
-            // 自动缩放
+            // Auto scale
             autoScale(shadowRoot, container);
         }
 
@@ -126,10 +126,10 @@ export default function emailHtmlTemplate(html, domain) {
             hostElement.style.zoom = scale;
         }
 
-        // 使用示例
+        // Example usage
         const exampleHtml = \`${html}\`;
 
-        // 渲染HTML
+        // Render HTML
         renderHTML(exampleHtml);
     </script>
 </body>

--- a/mail-worker/src/template/email-text.js
+++ b/mail-worker/src/template/email-text.js
@@ -17,7 +17,7 @@ export default function emailTextTemplate(text) {
         		padding: 10px 10px;
             width: 100%;
             height: 100%;
-            overflow: auto; /* 改为 auto 允许滚动 */
+            overflow: auto;
         }
 
         span {

--- a/mail-worker/src/utils/file-utils.js
+++ b/mail-worker/src/utils/file-utils.js
@@ -29,10 +29,10 @@ const fileUtils = {
 	},
 
 	/**
-	 * 将 Base64 数据转换为 File 对象（自动识别 MIME 类型和文件扩展名）
-	 * @param {string} base64Data 带有 data: 前缀的 base64 数据
-	 * @param {string} [customFilename] 可选，传入自定义文件名（不含扩展名）
-	 * @returns {File} File 对象
+	 * Convert Base64 data to a File object (auto-detects MIME type and file extension)
+	 * @param {string} base64Data base64 data with data: prefix
+	 * @param {string} [customFilename] optional custom filename (without extension)
+	 * @returns {File} File object
 	 */
 	base64ToFile(base64Data, customFilename) {
 		const match = base64Data.match(/^data:(image|jpeg|video)\/([a-zA-Z0-9.+-]+);base64,/);
@@ -40,8 +40,8 @@ const fileUtils = {
 			throw new Error('Invalid base64 data format');
 		}
 
-		const type = match[1]; // image 或 video
-		const ext = match[2];  // jpg, png, mp4 等
+		const type = match[1]; // image or video
+		const ext = match[2];  // jpg, png, mp4, etc.
 		const mimeType = `${type}/${ext}`;
 		const cleanBase64 = base64Data.replace(/^data:(image|jpeg|video)\/[a-zA-Z0-9.+-]+;base64,/, '');
 

--- a/mail-worker/wrangler-test.toml
+++ b/mail-worker/wrangler-test.toml
@@ -7,39 +7,39 @@ keep_vars = true
 enabled = true
 
 [[d1_databases]]
-binding = "db"			#d1数据库绑定名默认不可修改
-database_name = "test-email"		#d1数据库名字
-database_id = "e65f099d-796d-4eaa-8dff-529b368b20db"		#d1数据库id
+binding = "db"			#d1 database binding name, do not modify
+database_name = "test-email"		#d1 database name
+database_id = "e65f099d-796d-4eaa-8dff-529b368b20db"		#d1 database id
 
 [[kv_namespaces]]
-binding = "kv"			#kv绑定名默认不可修改
-id = "9be10cd058e04c55b526f8c0c116f50c"					#kv数据库id
+binding = "kv"			#kv binding name, do not modify
+id = "9be10cd058e04c55b526f8c0c116f50c"					#kv namespace id
 
-#(可选)
+#(optional)
 #[[r2_buckets]]
-#binding = "r2"			#r2对象存储绑定名默认不可修改
-#bucket_name = "test-email"		#r2对象存储桶的名字
+#binding = "r2"			#r2 object storage binding name, do not modify
+#bucket_name = "test-email"		#r2 bucket name
 
 [ai]
 binding = "ai"
 
 [assets]
-binding = "assets"		#静态资源绑定名默认不可修改
-directory = "./dist"	#前端vue项目打包的静态资源存放位置,默认dist
+binding = "assets"		#static assets binding name, do not modify
+directory = "./dist"	#frontend vue build output directory, default: dist
 not_found_handling = "single-page-application"
 run_worker_first = true
 
 [triggers]
-crons = ["*/30 * * * *", "0 16 * * *"]	#每30分钟刷新分析缓存，每天晚上12点执行每日任务
+crons = ["*/30 * * * *", "0 16 * * *"]	#refresh analysis cache every 30 min, run daily tasks at midnight
 
 
 [vars]
-ai_model = ""			#ai模型,不填默认使用@cf/meta/llama-3.1-8b-instruct
-analysis_cache = false			#是否开启分析数据缓存
-orm_log = false			#是否sql日志
-domain = ["example.com"]				#邮件域名可可配置多个 示例: ["example1.com","example2.com"]
-admin = "admin@example.com"				#管理员的邮箱	示例: admin@example.com
-jwt_secret = "b7f29a1d-18e2-4d3b-941f-f6b2c97c02fd"			#jwt令牌的密钥,随便填一串字符串
+ai_model = ""			#ai model, defaults to @cf/meta/llama-3.1-8b-instruct if empty
+analysis_cache = false			#enable analysis data cache
+orm_log = false			#enable sql logging
+domain = ["example.com"]				#email domain(s), multiple allowed, e.g.: ["example1.com","example2.com"]
+admin = "admin@example.com"				#admin email, e.g.: admin@example.com
+jwt_secret = "b7f29a1d-18e2-4d3b-941f-f6b2c97c02fd"			#jwt secret key, any random string
 
 [build]
 command = "pnpm --prefix ../mail-vue install && pnpm --prefix ../mail-vue run build"

--- a/mail-worker/wrangler.toml
+++ b/mail-worker/wrangler.toml
@@ -7,41 +7,41 @@ keep_vars = true
 enabled = true
 
 #[[d1_databases]]
-#binding = "db"			#d1数据库绑定名默认不可修改
-#database_name = ""		#d1数据库名字
-#database_id = ""		#d1数据库id
+#binding = "db"			#d1 database binding name, do not modify
+#database_name = ""		#d1 database name
+#database_id = ""		#d1 database id
 
 #[[kv_namespaces]]
-#binding = "kv"			#kv绑定名默认不可修改
-#id = ""					#kv数据库id
+#binding = "kv"			#kv binding name, do not modify
+#id = ""					#kv namespace id
 
 #[[r2_buckets]]
-#binding = "r2"			#r2对象存储绑定名默认不可修改
-#bucket_name = ""		#r2对象存储桶的名字
+#binding = "r2"			#r2 object storage binding name, do not modify
+#bucket_name = ""		#r2 bucket name
 
 #[[send_email]]
-#name = "email"			#CF发件, 配置后优先使用
+#name = "email"			#CF email sending, takes priority when configured
 
 [ai]
 binding = "ai"
 
 [assets]
-binding = "assets"		#静态资源绑定名默认不可修改
-directory = "./dist"	#前端vue项目打包的静态资源存放位置,默认dist
+binding = "assets"		#static assets binding name, do not modify
+directory = "./dist"	#frontend vue build output directory, default: dist
 not_found_handling = "single-page-application"
 run_worker_first = true
 
 [triggers]
-crons = ["*/30 * * * *", "0 16 * * *"]	#每30分钟刷新分析缓存，每天晚上12点执行每日任务
+crons = ["*/30 * * * *", "0 16 * * *"]	#refresh analysis cache every 30 min, run daily tasks at midnight
 
 
 [vars]
-#ai_model = ""			#ai模型,不填默认使用@cf/meta/llama-3.1-8b-instruct
-#analysis_cache = false			#是否开启分析数据缓存
-#orm_log = false			#是否sql日志
-#domain = []				#邮件域名可可配置多个 示例: ["example1.com","example2.com"]
-#admin = ""				#管理员的邮箱	示例: admin@example.com
-#jwt_secret = ""			#jwt令牌的密钥,随便填一串字符串
+#ai_model = ""			#ai model, defaults to @cf/meta/llama-3.1-8b-instruct if empty
+#analysis_cache = false			#enable analysis data cache
+#orm_log = false			#enable sql logging
+#domain = []				#email domain(s), multiple allowed, e.g.: ["example1.com","example2.com"]
+#admin = ""				#admin email, e.g.: admin@example.com
+#jwt_secret = ""			#jwt secret key, any random string
 
 [build]
 command = "pnpm --prefix ../mail-vue install && pnpm --prefix ../mail-vue run build"


### PR DESCRIPTION
Translate all non-i18n Chinese text across 33 files to English:
- Config comments in wrangler.toml and wrangler-test.toml
- Console error/warn messages in service and email handler files
- User-facing error messages (BizError strings) in backend services
- Hardcoded UI strings in login, user, and analysis views
- Code comments in templates, utilities, layout, and component files

Permission names in init.js SQL and en.js i18n keys are intentionally kept in Chinese as they serve as i18n lookup keys for the translation system.