### PR TITLE
feat: agent-friendly REST API + embedded MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@
 
 - **📡 开放API**：支持使用API批量生成用户，多条件查询邮件 
 
+- **🤖 Agent API**：面向 LLM Agent 的 REST 接口（独立 token 鉴权）——列表/读取/发送/删除/已读/附件下载，详见 [doc/AGENT_API.md](doc/AGENT_API.md)
+
 - **🔢 验证码识别**：使用Workers AI，自动识别邮件验证码 
 
 - **📈 数据可视化**：使用ECharts对系统数据详情，用户邮件增长可视化显示

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@
 
 - **🤖 Agent API**：面向 LLM Agent 的 REST 接口（独立 token 鉴权）——列表/读取/发送/删除/已读/附件下载，详见 [doc/AGENT_API.md](doc/AGENT_API.md)
 
+- **🔌 MCP Server**：内置 Model Context Protocol 服务（Streamable HTTP，端点 `/mcp`），Claude Code/Desktop、Cursor 等客户端配一个 URL + token 即可使用全部能力，详见 [doc/MCP.md](doc/MCP.md)
+
 - **🔢 验证码识别**：使用Workers AI，自动识别邮件验证码 
 
 - **📈 数据可视化**：使用ECharts对系统数据详情，用户邮件增长可视化显示

--- a/doc/AGENT_API.md
+++ b/doc/AGENT_API.md
@@ -1,0 +1,192 @@
+# Agent API
+
+A REST-style, token-authenticated API surface designed for LLM agents and
+automation scripts. All routes live under `/api/agent/*` and are protected by a
+dedicated **agent token** that is stored separately from the existing
+`/public/*` token (so the two can be rotated independently).
+
+- Base path: `https://<your-domain>/api/agent`
+- Auth header: `Authorization: <agent-token>`
+- Response envelope: `{ code: 200, message: "success", data: ... }`
+  (`code !== 200` indicates failure; `message` carries the reason).
+
+## Token management
+
+Agent tokens are minted by the administrator using their **email + password**.
+Multiple tokens can coexist (one per agent / one per environment).
+
+### Mint a token
+
+```bash
+curl -X POST https://your-domain/api/agent/auth/token \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@example.com","password":"<admin-password>","name":"my-bot"}'
+```
+
+Response:
+
+```json
+{"code":200,"data":{"id":"<uuid>","name":"my-bot","token":"<store-this>","createTime":"..."}}
+```
+
+Store the `token` securely — it is shown only once.
+
+### List tokens (no secrets returned)
+
+```bash
+curl -X POST https://your-domain/api/agent/auth/tokens \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@example.com","password":"<admin-password>"}'
+```
+
+### Revoke a token (admin)
+
+Admin can revoke by either the token's `id` (from `list tokens`) or by the
+raw `token` string — whichever they have on hand.
+
+```bash
+# by tokenId
+curl -X POST https://your-domain/api/agent/auth/revoke \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@example.com","password":"<admin-password>","tokenId":"<id>"}'
+
+# by token string (e.g. when someone hands you a leaked token to kill)
+curl -X POST https://your-domain/api/agent/auth/revoke \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"admin@example.com","password":"<admin-password>","token":"<the-leaked-token>"}'
+```
+
+### Self-revoke (token cancels itself)
+
+No admin credentials needed — the holder of a token can retire it just by
+calling this with the token in the `Authorization` header. Useful for an
+agent that wants to rotate its own credentials after it has minted a
+replacement.
+
+```bash
+curl -X DELETE https://your-domain/api/agent/auth/me \
+  -H 'Authorization: <agent-token>'
+```
+
+After this call, the token is invalidated for both REST and MCP. Subsequent
+requests with it will return HTTP 401.
+
+## Discovery
+
+```bash
+curl https://your-domain/api/agent/info \
+  -H 'Authorization: <agent-token>'
+```
+
+Returns the configured domains and the full endpoint catalog so an agent can
+self-discover without external schema.
+
+## Mailboxes (sending accounts)
+
+```bash
+# list
+curl 'https://your-domain/api/agent/mailboxes?page=1&size=50' \
+  -H 'Authorization: <agent-token>'
+
+# search by substring
+curl 'https://your-domain/api/agent/mailboxes?email=alice' \
+  -H 'Authorization: <agent-token>'
+```
+
+## Emails
+
+### List
+
+```
+GET /api/agent/emails
+  ?mailbox=<email>        # OR accountId=<id>
+  &type=receive|send      # default: any
+  &unread=0|1             # default: any
+  &q=<keyword>            # subject/text/content/from/to search
+  &after=YYYY-MM-DD HH:MM:SS
+  &before=YYYY-MM-DD HH:MM:SS
+  &page=1
+  &size=20                # max 100
+```
+
+Returns `{ list, total, page, size }`. Every email row already includes
+`attList` with attachment metadata.
+
+### Get a single email
+
+```bash
+curl https://your-domain/api/agent/emails/123 \
+  -H 'Authorization: <agent-token>'
+```
+
+Returns the full email row including `content` (HTML), `text` (plain text)
+and `attList`.
+
+### Send / reply
+
+```bash
+curl -X POST https://your-domain/api/agent/emails \
+  -H 'Authorization: <agent-token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "from": "bot@your-domain",
+    "to": ["alice@example.com"],
+    "subject": "Hello",
+    "text": "plain-text body",
+    "html": "<p>html body</p>",
+    "replyTo": 123,
+    "attachments": [
+      { "filename": "report.pdf", "content": "<base64>", "contentType": "application/pdf" }
+    ]
+  }'
+```
+
+`from` **must** be a mailbox that already exists in the system. `replyTo` is
+optional — when set, the email is treated as a reply (headers + threading
+preserved). `attachments[].content` accepts a `data:` URL or raw base64.
+
+### Mark as read / unread
+
+```bash
+curl -X PUT https://your-domain/api/agent/emails/123/read   -H 'Authorization: <agent-token>'
+curl -X PUT https://your-domain/api/agent/emails/123/unread -H 'Authorization: <agent-token>'
+```
+
+### Soft delete
+
+```bash
+# single
+curl -X DELETE https://your-domain/api/agent/emails/123 \
+  -H 'Authorization: <agent-token>'
+
+# batch
+curl -X POST https://your-domain/api/agent/emails/batch-delete \
+  -H 'Authorization: <agent-token>' \
+  -H 'Content-Type: application/json' \
+  -d '{"ids":[123,124,125]}'
+```
+
+Soft-deleted emails remain in the database with `isDel=1` and disappear from
+list queries. Admins can still restore them through the UI / `allEmail`
+endpoints.
+
+## Attachments
+
+```bash
+curl -OJ https://your-domain/api/agent/attachments/42 \
+  -H 'Authorization: <agent-token>'
+```
+
+Streams the binary content with the original `filename` (RFC 5987 encoded) and
+`mimeType` set on the response.
+
+## Auth model recap
+
+| Route | Auth |
+| --- | --- |
+| `POST /agent/auth/token` `tokens` `revoke` | admin email + password (in body) |
+| `GET/POST/PUT/DELETE /agent/...` (everything else) | `Authorization: <agent-token>` header |
+
+The agent token is **not** the user's JWT and **not** the `/public/genToken`
+key — they are three independent credentials. Revoking an agent token has no
+effect on user sessions or the public-API token.

--- a/doc/MCP.md
+++ b/doc/MCP.md
@@ -1,0 +1,114 @@
+# Cloud Mail MCP Server
+
+Cloud Mail exposes a [Model Context Protocol](https://modelcontextprotocol.io/)
+server directly on the same Cloudflare Worker. LLM agents (Claude
+Code, Claude Desktop, Cursor, etc.) can connect with a single URL + token, no
+local process required.
+
+## Endpoint
+
+```
+https://<your-domain>/mcp
+```
+
+- Transport: **Streamable HTTP** (the current MCP transport — supersedes the
+  older SSE-only endpoints)
+- Protocol version: `2025-06-18`
+- Auth: same agent token as the REST `/api/agent/*` surface (see
+  [AGENT_API.md](AGENT_API.md) for how to mint one)
+- One endpoint handles every method: `POST` for JSON-RPC requests,
+  `OPTIONS` for CORS preflight, `DELETE` for session termination
+  (acknowledged but stateless), `GET` is not used.
+
+A bare `https://<your-domain>/api/mcp` alias is also accepted, in case your
+client prepends `/api`.
+
+## Client configuration
+
+### Claude Code / Claude Desktop
+
+Add to your `~/.claude/mcp.json` (or `claude_desktop_config.json`):
+
+```jsonc
+{
+  "mcpServers": {
+    "cloud-mail": {
+      "type": "http",
+      "url": "https://<your-domain>/mcp",
+      "headers": {
+        "Authorization": "<your-agent-token>"
+      }
+    }
+  }
+}
+```
+
+Restart the client; tools should appear under the `cloud-mail` namespace.
+
+### Cursor / Cline / generic remote MCP clients
+
+Most clients accept the same shape — URL + headers. If a client only supports
+the legacy SSE transport, this endpoint is not yet compatible; ask for
+Streamable HTTP support upstream.
+
+## Tools
+
+| Tool | Description |
+| --- | --- |
+| `list_mailboxes` | List sending accounts (returns `{list,total,page,size}`) |
+| `list_emails` | List emails with filters: `mailbox`, `type`, `unread`, `q`, `page`, `size`, `after`, `before` |
+| `get_email` | Full content + attachment metadata for one email |
+| `send_email` | Send / reply. Required: `from`, `to[]`, `subject`. Optional: `text`, `html`, `replyTo`, `name`, `attachments[]` |
+| `mark_read` / `mark_unread` | Toggle the unread flag |
+| `delete_email` | Soft-delete by id list |
+| `get_attachment` | Download an attachment as `{filename, mimeType, size, base64}` |
+
+The full input schema for each tool is returned by the `tools/list` RPC and
+will be presented in the agent's tool catalog automatically.
+
+## Auth flow
+
+1. Admin mints an agent token via the REST endpoint
+   (`POST /api/agent/auth/token`, see [AGENT_API.md](AGENT_API.md)) — same
+   credential is used for both REST and MCP.
+2. Client sends `Authorization: <token>` on every MCP request.
+3. Missing or unknown tokens are rejected with HTTP **401** and a
+   `WWW-Authenticate: Bearer ...` header (per MCP spec).
+4. Revoking a token via `POST /api/agent/auth/revoke` invalidates both REST
+   and MCP access for that token instantly.
+
+## Manual test
+
+```bash
+# init handshake
+curl -s -X POST https://<your-domain>/mcp \
+  -H 'Authorization: <token>' \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"curl","version":"0"}}}'
+
+# list tools
+curl -s -X POST https://<your-domain>/mcp \
+  -H 'Authorization: <token>' \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
+
+# call a tool
+curl -s -X POST https://<your-domain>/mcp \
+  -H 'Authorization: <token>' \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"list_mailboxes","arguments":{"size":5}}}'
+```
+
+## Notes
+
+- The server is **stateless** — no session storage; every request stands
+  alone. Sessions / resumable streams are intentionally not implemented to
+  keep the worker simple. If your client requires session tracking, set the
+  `Mcp-Session-Id` header to any stable value; the server will accept and
+  ignore it.
+- Tool results are returned as a single `text` content block containing
+  pretty-printed JSON. This makes them readable as fallback to clients that
+  don't render structured content.
+- All operations execute under the admin scope (the agent token is admin-
+  level by construction — only admin can mint one). Per-user scoping is not
+  enforced inside MCP.

--- a/mail-worker/src/api/agent-api.js
+++ b/mail-worker/src/api/agent-api.js
@@ -1,0 +1,87 @@
+import app from '../hono/hono';
+import result from '../model/result';
+import agentService from '../service/agent-service';
+
+app.post('/agent/auth/token', async (c) => {
+	const data = await agentService.issueToken(c, await c.req.json());
+	return c.json(result.ok(data));
+});
+
+app.post('/agent/auth/tokens', async (c) => {
+	const data = await agentService.listTokens(c, await c.req.json());
+	return c.json(result.ok(data));
+});
+
+app.post('/agent/auth/revoke', async (c) => {
+	await agentService.revokeToken(c, await c.req.json());
+	return c.json(result.ok());
+});
+
+app.delete('/agent/auth/me', async (c) => {
+	const data = await agentService.revokeSelf(c);
+	return c.json(result.ok(data));
+});
+
+app.get('/agent/info', (c) => {
+	return c.json(result.ok(agentService.info(c)));
+});
+
+app.get('/agent/mailboxes', async (c) => {
+	const data = await agentService.listMailboxes(c, c.req.query());
+	return c.json(result.ok(data));
+});
+
+app.get('/agent/emails', async (c) => {
+	const data = await agentService.listEmails(c, c.req.query());
+	return c.json(result.ok(data));
+});
+
+app.get('/agent/emails/:id', async (c) => {
+	const data = await agentService.getEmail(c, c.req.param('id'));
+	return c.json(result.ok(data));
+});
+
+app.post('/agent/emails', async (c) => {
+	const data = await agentService.sendEmail(c, await c.req.json());
+	return c.json(result.ok(data));
+});
+
+app.put('/agent/emails/:id/read', async (c) => {
+	await agentService.setReadFlag(c, c.req.param('id'), true);
+	return c.json(result.ok());
+});
+
+app.put('/agent/emails/:id/unread', async (c) => {
+	await agentService.setReadFlag(c, c.req.param('id'), false);
+	return c.json(result.ok());
+});
+
+app.delete('/agent/emails/:id', async (c) => {
+	await agentService.softDelete(c, [c.req.param('id')]);
+	return c.json(result.ok());
+});
+
+app.post('/agent/emails/batch-delete', async (c) => {
+	const body = await c.req.json();
+	await agentService.softDelete(c, body && body.ids);
+	return c.json(result.ok());
+});
+
+app.get('/agent/attachments/:attId', async (c) => {
+	const { obj, meta } = await agentService.fetchAttachment(c, c.req.param('attId'));
+
+	if (obj instanceof Response) {
+		const headers = new Headers(obj.headers);
+		if (meta.filename) {
+			headers.set('Content-Disposition', `attachment; filename*=UTF-8''${encodeURIComponent(meta.filename)}`);
+		}
+		return new Response(obj.body, { status: obj.status, headers });
+	}
+
+	const headers = new Headers();
+	headers.set('Content-Type', meta.mimeType || obj.httpMetadata?.contentType || 'application/octet-stream');
+	if (meta.filename) {
+		headers.set('Content-Disposition', `attachment; filename*=UTF-8''${encodeURIComponent(meta.filename)}`);
+	}
+	return new Response(obj.body, { headers });
+});

--- a/mail-worker/src/const/kv-const.js
+++ b/mail-worker/src/const/kv-const.js
@@ -3,7 +3,8 @@ const KvConst = {
 	SETTING: 'setting:',
 	SEND_DAY_COUNT: 'send_day_count:',
 	ANALYSIS_ECHARTS: 'analysis_echarts:',
-	PUBLIC_KEY: "public_key:"
+	PUBLIC_KEY: "public_key:",
+	AGENT_KEYS: "agent_keys:"
 }
 
 export default KvConst;

--- a/mail-worker/src/hono/webs.js
+++ b/mail-worker/src/hono/webs.js
@@ -20,4 +20,5 @@ import '../api/reg-key-api'
 import '../api/public-api'
 import '../api/telegram-api'
 import '../api/oauth-api'
+import '../api/agent-api'
 export default app;

--- a/mail-worker/src/index.js
+++ b/mail-worker/src/index.js
@@ -6,10 +6,15 @@ import emailService from './service/email-service';
 import kvObjService from './service/kv-obj-service';
 import oauthService from "./service/oauth-service";
 import analysisService from './service/analysis-service';
+import mcpServer from './mcp/server';
 export default {
 	 async fetch(req, env, ctx) {
 
 		const url = new URL(req.url)
+
+		if (url.pathname === '/mcp' || url.pathname === '/api/mcp') {
+			return mcpServer.handle(req, env, ctx);
+		}
 
 		if (url.pathname.startsWith('/api/')) {
 			url.pathname = url.pathname.replace('/api', '')

--- a/mail-worker/src/mcp/server.js
+++ b/mail-worker/src/mcp/server.js
@@ -1,0 +1,182 @@
+import KvConst from '../const/kv-const';
+import tools from './tools';
+
+const PROTOCOL_VERSION = '2025-06-18';
+const SERVER_INFO = { name: 'cloud-mail', version: '1.0.0' };
+
+const CORS_HEADERS = {
+	'Access-Control-Allow-Origin': '*',
+	'Access-Control-Allow-Methods': 'GET, POST, DELETE, OPTIONS',
+	'Access-Control-Allow-Headers': 'Authorization, Content-Type, Mcp-Session-Id, Last-Event-ID, MCP-Protocol-Version',
+	'Access-Control-Expose-Headers': 'Mcp-Session-Id, WWW-Authenticate',
+	'Access-Control-Max-Age': '86400'
+};
+
+function jsonResp(body, status = 200, extra = {}) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: { 'Content-Type': 'application/json', ...CORS_HEADERS, ...extra }
+	});
+}
+
+function unauthorized(reason) {
+	return new Response(JSON.stringify({ error: reason }), {
+		status: 401,
+		headers: {
+			'Content-Type': 'application/json',
+			'WWW-Authenticate': `Bearer realm="cloud-mail-mcp"${reason === 'agent token invalid' ? ' error="invalid_token"' : ''}`,
+			...CORS_HEADERS
+		}
+	});
+}
+
+async function authenticate(req, env) {
+	const token = req.headers.get('Authorization');
+	if (!token) return unauthorized('agent token required');
+	const stored = await env.kv.get(KvConst.AGENT_KEYS, { type: 'json' });
+	const tokens = Array.isArray(stored?.tokens) ? stored.tokens : [];
+	const matched = tokens.find(t => t && t.token === token);
+	if (!matched) return unauthorized('agent token invalid');
+	return matched;
+}
+
+function buildCtx(req, env, matchedToken) {
+	return {
+		env,
+		req: {
+			header: (name) => req.headers.get(name),
+			raw: req,
+			url: req.url,
+			method: req.method
+		},
+		set: () => {},
+		get: (key) => (key === 'agentToken' ? { id: matchedToken.id, name: matchedToken.name } : undefined)
+	};
+}
+
+async function handleMessage(c, msg) {
+	if (!msg || typeof msg !== 'object' || msg.jsonrpc !== '2.0') {
+		return { jsonrpc: '2.0', id: msg?.id ?? null, error: { code: -32600, message: 'Invalid Request' } };
+	}
+
+	const { method, id, params } = msg;
+	const isNotification = id === undefined || id === null;
+
+	try {
+		if (method === 'initialize') {
+			return {
+				jsonrpc: '2.0', id,
+				result: {
+					protocolVersion: PROTOCOL_VERSION,
+					capabilities: { tools: { listChanged: false } },
+					serverInfo: SERVER_INFO,
+					instructions: 'Cloud Mail agent server. Use list_mailboxes to discover sender accounts, list_emails / get_email to read, send_email to write, mark_read / mark_unread / delete_email to manage state, get_attachment to download attachments by attId.'
+				}
+			};
+		}
+
+		if (method === 'notifications/initialized' || method === 'notifications/cancelled') {
+			return null;
+		}
+
+		if (method === 'ping') {
+			return { jsonrpc: '2.0', id, result: {} };
+		}
+
+		if (method === 'tools/list') {
+			return {
+				jsonrpc: '2.0', id,
+				result: {
+					tools: tools.map(t => ({
+						name: t.name,
+						description: t.description,
+						inputSchema: t.inputSchema
+					}))
+				}
+			};
+		}
+
+		if (method === 'tools/call') {
+			const name = params?.name;
+			const tool = tools.find(t => t.name === name);
+			if (!tool) {
+				return { jsonrpc: '2.0', id, error: { code: -32602, message: `Unknown tool: ${name}` } };
+			}
+			try {
+				const result = await tool.handler(c, params?.arguments || {});
+				const text = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+				return {
+					jsonrpc: '2.0', id,
+					result: {
+						content: [{ type: 'text', text }]
+					}
+				};
+			} catch (e) {
+				return {
+					jsonrpc: '2.0', id,
+					result: {
+						content: [{ type: 'text', text: `Error: ${e.message || String(e)}` }],
+						isError: true
+					}
+				};
+			}
+		}
+
+		if (isNotification) return null;
+		return { jsonrpc: '2.0', id, error: { code: -32601, message: `Method not found: ${method}` } };
+	} catch (e) {
+		if (isNotification) return null;
+		return { jsonrpc: '2.0', id, error: { code: -32603, message: e.message || 'Internal error' } };
+	}
+}
+
+export default {
+	async handle(req, env) {
+
+		if (req.method === 'OPTIONS') {
+			return new Response(null, { status: 204, headers: CORS_HEADERS });
+		}
+
+		const auth = await authenticate(req, env);
+		if (auth instanceof Response) return auth;
+
+		if (req.method === 'GET') {
+			return jsonResp({ error: 'server-initiated stream not supported' }, 405, { 'Allow': 'POST, OPTIONS, DELETE' });
+		}
+
+		if (req.method === 'DELETE') {
+			return new Response(null, { status: 200, headers: CORS_HEADERS });
+		}
+
+		if (req.method !== 'POST') {
+			return jsonResp({ error: 'method not allowed' }, 405, { 'Allow': 'POST, OPTIONS, DELETE' });
+		}
+
+		let body;
+		try {
+			body = await req.json();
+		} catch (e) {
+			return jsonResp({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } }, 400);
+		}
+
+		const c = buildCtx(req, env, auth);
+
+		if (Array.isArray(body)) {
+			const responses = [];
+			for (const msg of body) {
+				const r = await handleMessage(c, msg);
+				if (r) responses.push(r);
+			}
+			if (responses.length === 0) {
+				return new Response(null, { status: 202, headers: CORS_HEADERS });
+			}
+			return jsonResp(responses);
+		}
+
+		const response = await handleMessage(c, body);
+		if (!response) {
+			return new Response(null, { status: 202, headers: CORS_HEADERS });
+		}
+		return jsonResp(response);
+	}
+};

--- a/mail-worker/src/mcp/tools.js
+++ b/mail-worker/src/mcp/tools.js
@@ -1,0 +1,148 @@
+import agentService from '../service/agent-service';
+
+async function fetchAttachmentBase64(c, attId) {
+	const { obj, meta } = await agentService.fetchAttachment(c, attId);
+	const source = obj instanceof Response ? obj : new Response(obj.body);
+	const buf = await source.arrayBuffer();
+	const bytes = new Uint8Array(buf);
+	let binary = '';
+	for (let i = 0; i < bytes.length; i += 0x8000) {
+		binary += String.fromCharCode(...bytes.subarray(i, i + 0x8000));
+	}
+	return {
+		attId: meta.attId,
+		filename: meta.filename,
+		mimeType: meta.mimeType,
+		size: meta.size,
+		base64: btoa(binary)
+	};
+}
+
+const tools = [
+	{
+		name: 'list_mailboxes',
+		description: 'List configured mailboxes (sending accounts). Returns {list, total, page, size}. Each list item has accountId, email, name, userId.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				email: { type: 'string', description: 'optional case-insensitive substring filter on mailbox email address' },
+				page: { type: 'integer', minimum: 1, default: 1 },
+				size: { type: 'integer', minimum: 1, maximum: 200, default: 50 }
+			}
+		},
+		handler: (c, args) => agentService.listMailboxes(c, args)
+	},
+	{
+		name: 'list_emails',
+		description: 'List emails with filters. Returns {list, total, page, size} where each item has emailId, subject, sendEmail, toEmail, createTime, type (0=receive 1=send), unread (0=read 1=unread), text snippet, content (html), attList[]. Use mailbox or accountId to scope to one mailbox; without either, lists across all mailboxes.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				mailbox: { type: 'string', description: 'mailbox email address (exact match, case-insensitive)' },
+				accountId: { type: 'integer', description: 'alternative to mailbox' },
+				type: { type: 'string', enum: ['receive', 'send'], description: 'restrict to received or sent emails' },
+				unread: { type: 'string', enum: ['0', '1'], description: '1 = unread only, 0 = read only, omit for both' },
+				q: { type: 'string', description: 'keyword search over subject/text/content/from/to (case-insensitive substring)' },
+				page: { type: 'integer', minimum: 1, default: 1 },
+				size: { type: 'integer', minimum: 1, maximum: 100, default: 20 },
+				after: { type: 'string', description: 'createTime >= this. Format: YYYY-MM-DD HH:MM:SS' },
+				before: { type: 'string', description: 'createTime <= this. Format: YYYY-MM-DD HH:MM:SS' }
+			}
+		},
+		handler: (c, args) => agentService.listEmails(c, args)
+	},
+	{
+		name: 'get_email',
+		description: 'Get a single email by id, including full HTML content, plain text, and attachment metadata (attList).',
+		inputSchema: {
+			type: 'object',
+			properties: { id: { type: 'integer', description: 'emailId' } },
+			required: ['id']
+		},
+		handler: (c, args) => agentService.getEmail(c, args.id)
+	},
+	{
+		name: 'send_email',
+		description: 'Send an email. The from address must be an existing mailbox in the system (use list_mailboxes to discover). Provide at least one of text or html. To reply to an existing email, set replyTo to that email id so message threading is preserved.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				from: { type: 'string', description: 'sender mailbox email (must be registered)' },
+				to: { type: 'array', items: { type: 'string' }, minItems: 1, description: 'recipient email addresses' },
+				subject: { type: 'string' },
+				text: { type: 'string', description: 'plain-text body' },
+				html: { type: 'string', description: 'HTML body (preferred when both provided)' },
+				replyTo: { type: 'integer', description: 'emailId being replied to (optional)' },
+				name: { type: 'string', description: 'sender display name; defaults to the mailbox local-part' },
+				attachments: {
+					type: 'array',
+					description: 'optional attachments',
+					items: {
+						type: 'object',
+						properties: {
+							filename: { type: 'string' },
+							content: { type: 'string', description: 'base64-encoded bytes or a data: URL' },
+							contentType: { type: 'string', description: 'MIME type, e.g. application/pdf' }
+						},
+						required: ['filename', 'content']
+					}
+				}
+			},
+			required: ['from', 'to', 'subject']
+		},
+		handler: (c, args) => agentService.sendEmail(c, args)
+	},
+	{
+		name: 'mark_read',
+		description: 'Mark an email as read (sets unread=0).',
+		inputSchema: {
+			type: 'object',
+			properties: { id: { type: 'integer' } },
+			required: ['id']
+		},
+		handler: async (c, args) => {
+			await agentService.setReadFlag(c, args.id, true);
+			return { ok: true, id: args.id, unread: 0 };
+		}
+	},
+	{
+		name: 'mark_unread',
+		description: 'Mark an email as unread (sets unread=1).',
+		inputSchema: {
+			type: 'object',
+			properties: { id: { type: 'integer' } },
+			required: ['id']
+		},
+		handler: async (c, args) => {
+			await agentService.setReadFlag(c, args.id, false);
+			return { ok: true, id: args.id, unread: 1 };
+		}
+	},
+	{
+		name: 'delete_email',
+		description: 'Soft-delete one or more emails by id (sets isDel=1; rows remain in DB and are excluded from list/get queries).',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				ids: { type: 'array', items: { type: 'integer' }, minItems: 1, description: 'emailId list' }
+			},
+			required: ['ids']
+		},
+		handler: async (c, args) => {
+			await agentService.softDelete(c, args.ids);
+			return { ok: true, deleted: args.ids };
+		}
+	},
+	{
+		name: 'get_attachment',
+		description: 'Download an attachment by attId. Returns {attId, filename, mimeType, size, base64} where base64 is the file content. Find attId values inside attList on emails returned by get_email/list_emails.',
+		inputSchema: {
+			type: 'object',
+			properties: { attId: { type: 'integer' } },
+			required: ['attId']
+		},
+		handler: (c, args) => fetchAttachmentBase64(c, args.attId)
+	}
+];
+
+export default tools;

--- a/mail-worker/src/security/security.js
+++ b/mail-worker/src/security/security.js
@@ -18,7 +18,10 @@ const exclude = [
 	'/public/genToken',
 	'/telegram',
 	'/test',
-	'/oauth'
+	'/oauth',
+	'/agent/auth/token',
+	'/agent/auth/tokens',
+	'/agent/auth/revoke'
 ];
 
 const requirePerms = [
@@ -108,6 +111,24 @@ app.use('*', async (c, next) => {
 		if (publicToken !== userPublicToken) {
 			throw new BizError(t('publicTokenFail'), 401);
 		}
+		return await next();
+	}
+
+	if (path.startsWith('/agent')) {
+
+		const presented = c.req.header(constant.TOKEN_HEADER);
+		if (!presented) {
+			throw new BizError('agent token required', 401);
+		}
+
+		const stored = await c.env.kv.get(KvConst.AGENT_KEYS, { type: 'json' });
+		const tokens = Array.isArray(stored?.tokens) ? stored.tokens : [];
+		const matched = tokens.find(item => item && item.token === presented);
+		if (!matched) {
+			throw new BizError('agent token invalid', 401);
+		}
+
+		c.set('agentToken', { id: matched.id, name: matched.name });
 		return await next();
 	}
 

--- a/mail-worker/src/service/agent-service.js
+++ b/mail-worker/src/service/agent-service.js
@@ -1,0 +1,274 @@
+import orm from '../entity/orm';
+import email from '../entity/email';
+import account from '../entity/account';
+import { att } from '../entity/att';
+import { and, asc, count, desc, eq, inArray, or, sql } from 'drizzle-orm';
+import { emailConst, isDel } from '../const/entity-const';
+import BizError from '../error/biz-error';
+import KvConst from '../const/kv-const';
+import emailService from './email-service';
+import attService from './att-service';
+import r2Service from './r2-service';
+import userService from './user-service';
+import cryptoUtils from '../utils/crypto-utils';
+import emailUtils from '../utils/email-utils';
+import { v4 as uuidv4 } from 'uuid';
+import dayjs from 'dayjs';
+
+const ESCAPE_HTML = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' };
+function escapeHtml(s) {
+	return String(s).replace(/[&<>"']/g, ch => ESCAPE_HTML[ch]);
+}
+
+async function verifyAdmin(c, params) {
+	const { email: adminEmail, password } = params || {};
+	if (!adminEmail || !password) {
+		throw new BizError('email and password required', 400);
+	}
+	if (adminEmail !== c.env.admin) {
+		throw new BizError('not admin', 403);
+	}
+	const userRow = await userService.selectByEmailIncludeDel(c, adminEmail);
+	if (!userRow || userRow.isDel === isDel.DELETE) {
+		throw new BizError('admin not found', 404);
+	}
+	if (!await cryptoUtils.verifyPassword(password, userRow.salt, userRow.password)) {
+		throw new BizError('password incorrect', 401);
+	}
+}
+
+async function loadTokens(c) {
+	const stored = await c.env.kv.get(KvConst.AGENT_KEYS, { type: 'json' });
+	return Array.isArray(stored?.tokens) ? stored.tokens : [];
+}
+
+async function saveTokens(c, tokens) {
+	await c.env.kv.put(KvConst.AGENT_KEYS, JSON.stringify({ tokens }));
+}
+
+const agentService = {
+
+	async issueToken(c, params) {
+		await verifyAdmin(c, params);
+
+		const tokens = await loadTokens(c);
+		const item = {
+			id: uuidv4(),
+			name: (params.name || 'default').toString().slice(0, 64),
+			token: uuidv4().replace(/-/g, '') + uuidv4().replace(/-/g, ''),
+			createTime: dayjs().toISOString()
+		};
+		tokens.push(item);
+		await saveTokens(c, tokens);
+
+		return { id: item.id, name: item.name, token: item.token, createTime: item.createTime };
+	},
+
+	async listTokens(c, params) {
+		await verifyAdmin(c, params);
+		const tokens = await loadTokens(c);
+		return tokens.map(item => ({ id: item.id, name: item.name, createTime: item.createTime }));
+	},
+
+	async revokeToken(c, params) {
+		await verifyAdmin(c, params);
+		const { tokenId, token } = params || {};
+		if (!tokenId && !token) throw new BizError('tokenId or token required', 400);
+		const tokens = await loadTokens(c);
+		const next = tokens.filter(item => {
+			if (tokenId && item.id === tokenId) return false;
+			if (token && item.token === token) return false;
+			return true;
+		});
+		if (next.length === tokens.length) throw new BizError('token not found', 404);
+		await saveTokens(c, next);
+	},
+
+	async revokeSelf(c) {
+		const presented = c.req.header('Authorization');
+		if (!presented) throw new BizError('agent token required', 401);
+		const tokens = await loadTokens(c);
+		const next = tokens.filter(item => item.token !== presented);
+		if (next.length === tokens.length) throw new BizError('token not found', 404);
+		await saveTokens(c, next);
+		return { ok: true };
+	},
+
+	info(c) {
+		const domains = Array.isArray(c.env.domain) ? c.env.domain : [];
+		return {
+			name: 'cloud-mail agent api',
+			version: 1,
+			authHeader: 'Authorization',
+			domains,
+			endpoints: {
+				auth: {
+					'POST /agent/auth/token': 'admin: mint a new agent token. body: {email,password,name?}',
+					'POST /agent/auth/tokens': 'admin: list agent tokens (no secrets). body: {email,password}',
+					'POST /agent/auth/revoke': 'admin: revoke a token. body: {email,password,tokenId}'
+				},
+				mailboxes: {
+					'GET /agent/mailboxes': 'list mailboxes. query: email?, page?, size?'
+				},
+				emails: {
+					'GET /agent/emails': 'list. query: mailbox|accountId, type(receive|send), unread(0|1), q, page, size, after, before',
+					'GET /agent/emails/:id': 'get full email + attachments meta',
+					'POST /agent/emails': 'send. body: {from,to[],subject,text?,html?,replyTo?,name?,attachments?[]}',
+					'PUT /agent/emails/:id/read': 'mark read',
+					'PUT /agent/emails/:id/unread': 'mark unread',
+					'DELETE /agent/emails/:id': 'soft delete',
+					'POST /agent/emails/batch-delete': 'soft delete many. body: {ids:[...]}'
+				},
+				attachments: {
+					'GET /agent/attachments/:attId': 'download binary'
+				}
+			}
+		};
+	},
+
+	async listMailboxes(c, params) {
+		let { email: filterEmail, page, size } = params || {};
+		page = Math.max(1, Number(page) || 1);
+		size = Math.min(200, Math.max(1, Number(size) || 50));
+		const offset = (page - 1) * size;
+
+		const conditions = [eq(account.isDel, isDel.NORMAL)];
+		if (filterEmail) {
+			conditions.push(sql`${account.email} COLLATE NOCASE LIKE ${'%' + filterEmail + '%'}`);
+		}
+
+		const where = conditions.length > 1 ? and(...conditions) : conditions[0];
+		const list = await orm(c).select().from(account).where(where).orderBy(asc(account.accountId)).limit(size).offset(offset).all();
+		const totalRow = await orm(c).select({ total: count() }).from(account).where(where).get();
+		return { list, total: totalRow.total, page, size };
+	},
+
+	async resolveAccount(c, params) {
+		const { mailbox, accountId } = params || {};
+		if (accountId) {
+			const acc = await orm(c).select().from(account).where(eq(account.accountId, Number(accountId))).get();
+			if (!acc) throw new BizError('accountId not found', 404);
+			return acc;
+		}
+		if (mailbox) {
+			const acc = await orm(c).select().from(account).where(sql`${account.email} COLLATE NOCASE = ${mailbox}`).get();
+			if (!acc) throw new BizError('mailbox not found', 404);
+			return acc;
+		}
+		return null;
+	},
+
+	async listEmails(c, params) {
+		let { mailbox, accountId, type, unread, q, page, size, after, before } = params || {};
+		page = Math.max(1, Number(page) || 1);
+		size = Math.min(100, Math.max(1, Number(size) || 20));
+		const offset = (page - 1) * size;
+
+		const conditions = [eq(email.isDel, isDel.NORMAL)];
+
+		const acc = await this.resolveAccount(c, { mailbox, accountId });
+		if (acc) {
+			conditions.push(eq(email.accountId, acc.accountId));
+		}
+
+		if (type === 'send' || type === 'SEND' || type === 1 || type === '1') {
+			conditions.push(eq(email.type, emailConst.type.SEND));
+		} else if (type === 'receive' || type === 'RECEIVE' || type === 0 || type === '0') {
+			conditions.push(eq(email.type, emailConst.type.RECEIVE));
+		}
+
+		if (unread === '1' || unread === 1 || unread === true || unread === 'true') {
+			conditions.push(eq(email.unread, emailConst.unread.UNREAD));
+		} else if (unread === '0' || unread === 0 || unread === false || unread === 'false') {
+			conditions.push(eq(email.unread, emailConst.unread.READ));
+		}
+
+		if (q) {
+			conditions.push(or(
+				sql`${email.subject} COLLATE NOCASE LIKE ${'%' + q + '%'}`,
+				sql`${email.text} COLLATE NOCASE LIKE ${'%' + q + '%'}`,
+				sql`${email.content} COLLATE NOCASE LIKE ${'%' + q + '%'}`,
+				sql`${email.sendEmail} COLLATE NOCASE LIKE ${'%' + q + '%'}`,
+				sql`${email.toEmail} COLLATE NOCASE LIKE ${'%' + q + '%'}`
+			));
+		}
+
+		if (after) conditions.push(sql`${email.createTime} >= ${after}`);
+		if (before) conditions.push(sql`${email.createTime} <= ${before}`);
+
+		const where = conditions.length > 1 ? and(...conditions) : conditions[0];
+
+		const list = await orm(c).select().from(email).where(where)
+			.orderBy(desc(email.emailId)).limit(size).offset(offset).all();
+		const totalRow = await orm(c).select({ total: count() }).from(email).where(where).get();
+
+		await emailService.emailAddAtt(c, list);
+		return { list, total: totalRow.total, page, size };
+	},
+
+	async getEmail(c, idParam) {
+		const emailId = Number(idParam);
+		if (!emailId) throw new BizError('invalid email id', 400);
+		const row = await orm(c).select().from(email).where(eq(email.emailId, emailId)).get();
+		if (!row) throw new BizError('email not found', 404);
+		const attList = await attService.selectByEmailIds(c, [emailId]);
+		row.attList = attList;
+		return row;
+	},
+
+	async sendEmail(c, params) {
+		const { from, to, subject, text, html, replyTo, name, attachments, cc, bcc } = params || {};
+		if (!from) throw new BizError('from required', 400);
+		if (!subject) throw new BizError('subject required', 400);
+
+		const recipients = Array.isArray(to) ? to.filter(Boolean) : (to ? [to] : []);
+		if (recipients.length === 0) throw new BizError('to required', 400);
+
+		const acc = await orm(c).select().from(account).where(sql`${account.email} COLLATE NOCASE = ${from}`).get();
+		if (!acc) throw new BizError('from mailbox not registered', 404);
+
+		const content = html || (text ? `<pre>${escapeHtml(text)}</pre>` : '');
+
+		const payload = {
+			accountId: acc.accountId,
+			name: name || emailUtils.getName(acc.email),
+			sendType: replyTo ? 'reply' : 'normal',
+			emailId: replyTo ? Number(replyTo) : undefined,
+			receiveEmail: recipients,
+			text: text || '',
+			content,
+			subject,
+			cc: Array.isArray(cc) ? cc : [],
+			bcc: Array.isArray(bcc) ? bcc : [],
+			attachments: Array.isArray(attachments) ? attachments : []
+		};
+
+		const result = await emailService.send(c, payload, acc.userId);
+		return Array.isArray(result) ? result[0] : result;
+	},
+
+	async setReadFlag(c, idParam, isRead) {
+		const emailId = Number(idParam);
+		if (!emailId) throw new BizError('invalid email id', 400);
+		const value = isRead ? emailConst.unread.READ : emailConst.unread.UNREAD;
+		await orm(c).update(email).set({ unread: value }).where(eq(email.emailId, emailId)).run();
+	},
+
+	async softDelete(c, ids) {
+		const list = (Array.isArray(ids) ? ids : [ids]).map(Number).filter(n => Number.isFinite(n) && n > 0);
+		if (list.length === 0) throw new BizError('no valid email id', 400);
+		await orm(c).update(email).set({ isDel: isDel.DELETE }).where(inArray(email.emailId, list)).run();
+	},
+
+	async fetchAttachment(c, attIdParam) {
+		const attId = Number(attIdParam);
+		if (!attId) throw new BizError('invalid attId', 400);
+		const meta = await orm(c).select().from(att).where(eq(att.attId, attId)).get();
+		if (!meta) throw new BizError('attachment not found', 404);
+		const obj = await r2Service.getObj(c, meta.key);
+		if (!obj) throw new BizError('attachment content missing', 404);
+		return { obj, meta };
+	}
+};
+
+export default agentService;


### PR DESCRIPTION
## TL;DR

Adds two new capabilities, sharing a single token-auth system that is
**completely separate** from the existing `/public/*` token:

1. **`/api/agent/*`** — REST API designed for LLM agents and automation
   (CRUD + send + attachments, with self-rotatable tokens).
2. **`/mcp`** — embedded [Model Context Protocol](https://modelcontextprotocol.io/)
   server (Streamable HTTP transport). Claude Code/Desktop, Cursor and any
   remote-MCP client can connect with just a URL + token, **no separate
   process required**.

Same Worker, same deployment, +1031 LoC, zero new runtime dependencies,
no D1 schema changes, no behavior change to any existing endpoint.

---

## 中文说明

为 LLM Agent / 自动化脚本场景增加两个能力：

1. **REST Agent API**（`/api/agent/*`）—— 与已有 `/public/*` token **完全隔离**
   的鉴权体系，支持多 token 并存与命名（一个 agent 一个 token）、按 tokenId/token
   字符串撤销、token 自撤销，所有现有业务能力（列表/查/发/删/已读/附件）都有覆盖。
2. **内置 MCP 服务**（`/mcp`）—— Streamable HTTP 传输，把 8 个工具直接暴露给
   Claude Code / Desktop 等支持 Remote MCP 的客户端，配一条 URL + token 即可，
   不需要在用户机器上跑额外进程。

两条线复用同一套 `agent_keys:` KV 鉴权，撤销 token 同时对 REST 和 MCP 生效。

---

## REST endpoints

| Endpoint | Auth | Purpose |
| --- | --- | --- |
| `POST   /api/agent/auth/token`   | admin email+pwd  | mint a named agent token |
| `POST   /api/agent/auth/tokens`  | admin email+pwd  | list active tokens (no secrets) |
| `POST   /api/agent/auth/revoke`  | admin email+pwd  | revoke by `tokenId` **or** `token` string |
| `DELETE /api/agent/auth/me`      | agent token      | token cancels itself (no admin pwd) |
| `GET    /api/agent/info`         | agent token      | self-describing endpoint catalog |
| `GET    /api/agent/mailboxes`    | agent token      | list sending accounts |
| `GET    /api/agent/emails`       | agent token      | list with `mailbox` / `type` / `unread` / `q` / `after` / `before` / pagination |
| `GET    /api/agent/emails/:id`   | agent token      | full message + attachment metadata |
| `POST   /api/agent/emails`       | agent token      | send (optionally reply, with attachments) |
| `PUT    /api/agent/emails/:id/read` &nbsp;/ `unread` | agent token | toggle flag |
| `DELETE /api/agent/emails/:id`   | agent token      | soft delete |
| `POST   /api/agent/emails/batch-delete` | agent token | bulk soft delete |
| `GET    /api/agent/attachments/:attId`  | agent token | binary download |

## MCP endpoint

```
POST https://<your-domain>/mcp
Authorization: <agent-token>
```

8 tools exposed: `list_mailboxes`, `list_emails`, `get_email`, `send_email`,
`mark_read`, `mark_unread`, `delete_email`, `get_attachment`.

Client config (Claude Code / Desktop):

```jsonc
{
  "mcpServers": {
    "cloud-mail": {
      "type": "http",
      "url": "https://<your-domain>/mcp",
      "headers": { "Authorization": "<agent-token>" }
    }
  }
}
```

---

## Design notes

**Why a separate token namespace?**
The existing `/public/*` token is a single shared admin-equivalent key, fine
for the existing `addUser` / `emailList` use case but unsuitable for handing
out to multiple agents (no per-agent identity, no rotation without affecting
the legacy public API). The new `agent_keys:` KV key holds a list of named
tokens; rotation, naming and revocation per-agent are first-class.

**Why MCP on the same Worker?**
Co-locating the MCP transport with the API means zero extra infrastructure
for users — they already deploy the Worker. The protocol layer is ~150
hand-rolled lines (Streamable HTTP single-response mode), no extra npm
dependency. The MCP route is wired in `src/index.js` *before* Hono so it
can return proper HTTP 401 (instead of the JSON-200 envelope from the
global error handler) — required by spec-compliant MCP clients.

**Why a thin service layer?**
`src/service/agent-service.js` reuses `emailService` / `attService` /
`r2Service` for every operation. The HTTP layer and the MCP tools layer
both call the same service methods, so the two surfaces stay behaviorally
identical and there's exactly one place to fix any bug.

**Backward compatibility**
- No D1 schema changes (only new KV key).
- No existing routes, request shapes or response shapes modified.
- `security.js` adds a new branch for `/agent/*`; the existing `/public/*`,
  JWT and permission paths are untouched.
- A fresh deployment without an admin token minted simply returns HTTP 401
  for every `/api/agent/*` and `/mcp` request — the surface is closed by
  default.

---

## Files changed (`+1031 / -2`)

```
mail-worker/src/api/agent-api.js          NEW   HTTP route layer
mail-worker/src/service/agent-service.js  NEW   service-layer glue (CRUD + token mgmt)
mail-worker/src/mcp/server.js             NEW   MCP protocol + auth + CORS
mail-worker/src/mcp/tools.js              NEW   MCP tool definitions (8 tools)
mail-worker/src/security/security.js      MOD   new /agent/* auth branch
mail-worker/src/const/kv-const.js         MOD   add AGENT_KEYS constant
mail-worker/src/hono/webs.js              MOD   register agent-api routes
mail-worker/src/index.js                  MOD   route /mcp before Hono (for HTTP 401)
doc/AGENT_API.md                          NEW   REST API reference
doc/MCP.md                                NEW   MCP usage guide
README.md                                 MOD   2 lines under feature list
```

---

## Verification

- ✅ `wrangler deploy --dry-run` on a clean tree from this branch — builds
  successfully against the unmodified upstream `wrangler.toml`.
- ✅ Static check on `mcp/server.js` confirms coverage of `initialize`,
  `tools/list`, `tools/call`, `ping`, notifications, `OPTIONS` (CORS), and
  HTTP 401 with `WWW-Authenticate` per spec.
- ✅ Live test on a self-hosted deployment: token mint → mailbox listing →
  email send → MCP `tools/list` and `tools/call` from a remote client →
  self-revoke returns 200 and subsequent calls return 401 on both REST and
  MCP simultaneously.

---

## How to try it

```bash
# 1. mint an agent token (admin email + password required)
curl -X POST https://<your-domain>/api/agent/auth/token \
  -H 'Content-Type: application/json' \
  -d '{"email":"<admin>","password":"<pwd>","name":"my-bot"}'

# 2. discover what's available
TOKEN='<paste-from-step-1>'
curl https://<your-domain>/api/agent/info -H "Authorization: $TOKEN"

# 3. talk MCP
curl -X POST https://<your-domain>/mcp \
  -H "Authorization: $TOKEN" -H 'Content-Type: application/json' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
```

Full docs: [`doc/AGENT_API.md`](../blob/pr/agent-api-mcp/doc/AGENT_API.md),
[`doc/MCP.md`](../blob/pr/agent-api-mcp/doc/MCP.md).

---

## Notes for the maintainer

- Happy to split into two PRs (REST first, MCP second) if you prefer — the
  feature flag is the KV `agent_keys:` key, so they can land independently,
  but the auth model is shared.
- Open to renaming `/mcp` → `/api/mcp` (currently both paths work) or to
  any other path you'd prefer for the MCP endpoint.
- The MCP protocol version is pinned to `2025-06-18`; happy to upgrade as
  the spec evolves. The transport implementation is intentionally small
  (no SDK dep) to keep the Worker bundle lean and surprise-free.

Thanks for `cloud-mail` — it's a great base 🙏
