### PR TITLE
feat: add Telegram link address display setting

### DIFF
--- a/mail-vue/src/i18n/en.js
+++ b/mail-vue/src/i18n/en.js
@@ -314,6 +314,7 @@ const en = {
     hide: 'Hide',
     onlyName: 'Only name',
     emailText: 'Email Text',
+    showFullLinkAddress: 'Show Full Link Address',
     emailPrefix: 'Email Prefix',
     atLeast: 'At Least',
     character: '',

--- a/mail-vue/src/i18n/zh.js
+++ b/mail-vue/src/i18n/zh.js
@@ -314,6 +314,7 @@ const zh = {
     hide: '隐藏',
     onlyName: '仅名字',
     emailText: '邮件文本',
+    showFullLinkAddress: '超链接显示完整地址',
     emailPrefix: '邮箱前缀',
     atLeast: '至少',
     character: '位',

--- a/mail-vue/src/views/sys-setting/index.vue
+++ b/mail-vue/src/views/sys-setting/index.vue
@@ -568,6 +568,17 @@
               />
             </el-select>
           </div>
+          <div class="tg-msg-label">
+            <span>{{t('showFullLinkAddress')}}</span>
+            <el-select  v-model="tgMsgLink" >
+              <el-option
+                  v-for="item in tgMsgLinkOption"
+                  :key="item.value"
+                  :label="item.label"
+                  :value="item.value"
+              />
+            </el-select>
+          </div>
         </div>
         <template #footer>
           <div class="dialog-footer">
@@ -938,10 +949,12 @@ const ruleEmail = ref([])
 const tgMsgFrom = ref('')
 const tgMsgTo = ref('')
 const tgMsgText = ref('')
+const tgMsgLink = ref('show')
 
 const tgMsgFromOption = [{label: t('show'), value: 'show'}, {label: t('hide'), value: 'hide'}, {label: t('onlyName'), value:'only-name'}]
 const tgMsgToOption = [{label: t('show'), value: 'show'}, {label: t('hide'), value: 'hide'}]
 const tgMsgTextOption = [{label: t('show'), value: 'show'}, {label: t('hide'), value: 'hide'}]
+const tgMsgLinkOption = [{label: t('show'), value: 'show'}, {label: t('hide'), value: 'hide'}]
 const tgMsgLabelWidth = computed(() => locale.value === 'en' ? '120px' : '100px');
 
 getSettings()
@@ -1069,6 +1082,7 @@ function openTgSetting() {
   tgMsgFrom.value = setting.value.tgMsgFrom
   tgMsgText.value = setting.value.tgMsgText
   tgMsgTo.value = setting.value.tgMsgTo
+  tgMsgLink.value = setting.value.tgMsgLink || 'show'
   tgChatId.value = []
   if (setting.value.tgChatId) {
     const list = setting.value.tgChatId.split(',')
@@ -1210,7 +1224,8 @@ function tgBotSave() {
     tgChatId: tgChatId.value + '',
     tgMsgFrom: tgMsgFrom.value,
     tgMsgText: tgMsgText.value,
-    tgMsgTo: tgMsgTo.value
+    tgMsgTo: tgMsgTo.value,
+    tgMsgLink: tgMsgLink.value
   }
   if (tgBotToken.value) form.tgBotToken = tgBotToken.value
   editSetting(form)

--- a/mail-worker/src/entity/setting.js
+++ b/mail-worker/src/entity/setting.js
@@ -46,6 +46,7 @@ export const setting = sqliteTable('setting', {
 	tgMsgFrom: text('tg_msg_from').default('only-name').notNull(),
 	tgMsgTo: text('tg_msg_to').default('show').notNull(),
 	tgMsgText: text('tg_msg_text').default('hide').notNull(),
+	tgMsgLink: text('tg_msg_link').default('show').notNull(),
 	minEmailPrefix: integer('min_email_prefix').default(0).notNull(),
 	emailPrefixFilter: text('email_prefix_filter').default('').notNull(),
 	blackSubject: text('black_subject').default('').notNull(),

--- a/mail-worker/src/init/init.js
+++ b/mail-worker/src/init/init.js
@@ -30,8 +30,17 @@ const dbInit = {
 		await this.v2_9DB(c);
 		await this.v3_0DB(c);
 		await this.v3_1DB(c);
+		await this.v3_2DB(c);
 		await settingService.refresh(c);
 		return c.text('success');
+	},
+
+	async v3_2DB(c) {
+		try {
+			await c.env.db.prepare(`ALTER TABLE setting ADD COLUMN tg_msg_link TEXT NOT NULL DEFAULT 'show';`).run();
+		} catch (e) {
+			console.warn(`跳过字段：${e.message}`);
+		}
 	},
 
 	async v3_1DB(c) {

--- a/mail-worker/src/service/telegram-service.js
+++ b/mail-worker/src/service/telegram-service.js
@@ -45,7 +45,7 @@ const telegramService = {
 
 	async sendEmailToBot(c, email) {
 
-		const { tgBotToken, tgChatId, customDomain, tgMsgTo, tgMsgFrom, tgMsgText } = await settingService.query(c);
+		const { tgBotToken, tgChatId, customDomain, tgMsgTo, tgMsgFrom, tgMsgText, tgMsgLink } = await settingService.query(c);
 
 		const tgChatIds = tgChatId.split(',');
 
@@ -80,7 +80,7 @@ const telegramService = {
 					body: JSON.stringify({
 						chat_id: chatId,
 						parse_mode: 'HTML',
-						text: emailMsgTemplate(email, tgMsgTo, tgMsgFrom, tgMsgText),
+						text: emailMsgTemplate(email, tgMsgTo, tgMsgFrom, tgMsgText, tgMsgLink),
 						reply_markup: {
 							inline_keyboard: inlineKeyboard
 						}

--- a/mail-worker/src/template/email-msg.js
+++ b/mail-worker/src/template/email-msg.js
@@ -39,8 +39,8 @@ function truncateText(text, maxLength) {
 
 function getEmailText(email, tgMsgLink) {
 	if (tgMsgLink === 'hide') {
-		return emailUtils.htmlToTelegramHtmlLinks(email.content)
-			|| emailUtils.textToTelegramHtmlLinks(email.text);
+		return emailUtils.textToTelegramHtmlLinks(email.text)
+			|| emailUtils.htmlToTelegramHtmlLinks(email.content);
 	}
 
 	return escapeHtml(emailUtils.formatText(email.text) || emailUtils.htmlToText(email.content));

--- a/mail-worker/src/template/email-msg.js
+++ b/mail-worker/src/template/email-msg.js
@@ -5,6 +5,7 @@ const TRUNCATED_SUFFIX = '...';
 
 function escapeHtml(text = '') {
 	return text
+		.replace(/&/g, '&amp;')
 		.replace(/</g, '&lt;')
 		.replace(/>/g, '&gt;');
 }
@@ -18,10 +19,34 @@ function truncateText(text, maxLength) {
 		return TRUNCATED_SUFFIX.slice(0, maxLength);
 	}
 
-	return text.slice(0, maxLength - TRUNCATED_SUFFIX.length) + TRUNCATED_SUFFIX;
+	let truncated = text.slice(0, maxLength - TRUNCATED_SUFFIX.length);
+	const lastTagStart = truncated.lastIndexOf('<');
+	const lastTagEnd = truncated.lastIndexOf('>');
+
+	if (lastTagStart > lastTagEnd) {
+		truncated = truncated.slice(0, lastTagStart);
+	}
+
+	const openLinkCount = (truncated.match(/<a\b[^>]*>/gi) || []).length;
+	const closeLinkCount = (truncated.match(/<\/a>/gi) || []).length;
+
+	if (openLinkCount > closeLinkCount) {
+		truncated += '</a>';
+	}
+
+	return truncated + TRUNCATED_SUFFIX;
 }
 
-export default function emailMsgTemplate(email, tgMsgTo, tgMsgFrom, tgMsgText) {
+function getEmailText(email, tgMsgLink) {
+	if (tgMsgLink === 'hide') {
+		return emailUtils.htmlToTelegramHtmlLinks(email.content)
+			|| emailUtils.textToTelegramHtmlLinks(email.text);
+	}
+
+	return escapeHtml(emailUtils.formatText(email.text) || emailUtils.htmlToText(email.content));
+}
+
+export default function emailMsgTemplate(email, tgMsgTo, tgMsgFrom, tgMsgText, tgMsgLink = 'show') {
 
 	let template = `<b>${escapeHtml(email.subject || '')}</b>`
 
@@ -47,7 +72,7 @@ To：\u200B${escapeHtml(email.toEmail || '')}`
 To：\u200B${escapeHtml(email.toEmail || '')}`
 	}
 
-	const text = escapeHtml(emailUtils.formatText(email.text) || emailUtils.htmlToText(email.content));
+	const text = getEmailText(email, tgMsgLink);
 
 	if(tgMsgText === 'show') {
 		const prefix = `${template}

--- a/mail-worker/src/utils/email-utils.js
+++ b/mail-worker/src/utils/email-utils.js
@@ -1,5 +1,99 @@
 import { parseHTML } from 'linkedom';
 
+const BLOCK_TAGS = new Set([
+	'address',
+	'article',
+	'aside',
+	'blockquote',
+	'dd',
+	'div',
+	'dl',
+	'dt',
+	'fieldset',
+	'figcaption',
+	'figure',
+	'footer',
+	'form',
+	'h1',
+	'h2',
+	'h3',
+	'h4',
+	'h5',
+	'h6',
+	'header',
+	'hr',
+	'li',
+	'main',
+	'nav',
+	'ol',
+	'p',
+	'pre',
+	'section',
+	'table',
+	'tbody',
+	'td',
+	'tfoot',
+	'th',
+	'thead',
+	'tr',
+	'ul'
+]);
+const SKIP_TAGS = new Set(['style', 'script', 'title', 'noscript']);
+const URL_PATTERN = /\b(?:https?:\/\/|www\.)[^\s<>()]+/gi;
+const FULL_LINK_PATTERN = /^(?:https?:\/\/|www\.)\S+$/i;
+
+function escapeTelegramHtml(text = '') {
+	return text
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;');
+}
+
+function escapeTelegramAttribute(text = '') {
+	return escapeTelegramHtml(text).replace(/"/g, '&quot;');
+}
+
+function normalizeLinkUrl(url = '') {
+	const value = url.trim();
+
+	if (!value || /^(?:javascript|data|vbscript):/i.test(value)) {
+		return '';
+	}
+
+	if (/^www\./i.test(value)) {
+		return `https://${value}`;
+	}
+
+	if (/^(?:https?:\/\/|mailto:)/i.test(value)) {
+		return value;
+	}
+
+	return '';
+}
+
+function splitTrailingPunctuation(url = '') {
+	const match = url.match(/^(.+?)([.,;!?]+)?$/);
+	return {
+		url: match?.[1] || url,
+		trailing: match?.[2] || ''
+	};
+}
+
+function normalizeTextNode(text = '') {
+	return text
+		.replace(/[\u200B-\u200F\uFEFF\u034F\u00A0\u3000\u00AD]/g, ' ')
+		.replace(/\s+/g, ' ');
+}
+
+function formatTelegramHtml(html = '') {
+	return html
+		.replace(/[ \t]+\n/g, '\n')
+		.replace(/\n[ \t]+/g, '\n')
+		.replace(/[ \t]{2,}/g, ' ')
+		.replace(/\n{3,}/g, '\n\n')
+		.trim();
+}
+
 const emailUtils = {
 
 	getDomain(email) {
@@ -26,6 +120,109 @@ const emailUtils = {
 			.join('\n')
 			.replace(/\n{3,}/g, '\n')
 			.trim();
+	},
+
+	hideFullLinkAddress(text) {
+		if (!text) return ''
+		return this.formatText(text)
+			.replace(/[ \t]*\(\s*(?:https?:\/\/|www\.)[^\n)]*\s*\)/gi, '')
+			.replace(/[ \t]*<\s*(?:https?:\/\/|www\.)[^>\n]*>/gi, '')
+			.replace(/\b(?:https?:\/\/|www\.)[^\s<>()]+/gi, '')
+			.replace(/[ \t]{2,}/g, ' ')
+			.replace(/\n{3,}/g, '\n')
+			.trim();
+	},
+
+	textToTelegramHtmlLinks(text) {
+		const formattedText = this.formatText(text);
+
+		if (!formattedText) {
+			return '';
+		}
+
+		let result = '';
+		let lastIndex = 0;
+
+		for (const match of formattedText.matchAll(URL_PATTERN)) {
+			const fullMatch = match[0];
+			const matchIndex = match.index;
+			const { url, trailing } = splitTrailingPunctuation(fullMatch);
+			const href = normalizeLinkUrl(url);
+
+			result += escapeTelegramHtml(formattedText.slice(lastIndex, matchIndex));
+			result += href
+				? `<a href="${escapeTelegramAttribute(href)}">jump</a>${escapeTelegramHtml(trailing)}`
+				: escapeTelegramHtml(fullMatch);
+			lastIndex = matchIndex + fullMatch.length;
+		}
+
+		result += escapeTelegramHtml(formattedText.slice(lastIndex));
+		return formatTelegramHtml(result);
+	},
+
+	htmlToTelegramHtmlLinks(content) {
+		if (!content) return ''
+
+		try {
+			const wrappedContent = content.includes('<body')
+				? content
+				: `<!DOCTYPE html><html><body>${content}</body></html>`;
+			const { document } = parseHTML(wrappedContent);
+			document.querySelectorAll('style, script, title, noscript').forEach(el => el.remove());
+
+			const renderNode = node => {
+				if (node.nodeType === 3) {
+					return escapeTelegramHtml(normalizeTextNode(node.nodeValue || ''));
+				}
+
+				if (node.nodeType !== 1) {
+					return '';
+				}
+
+				const tagName = node.localName?.toLowerCase() || '';
+
+				if (SKIP_TAGS.has(tagName)) {
+					return '';
+				}
+
+				if (tagName === 'br') {
+					return '\n';
+				}
+
+				if (tagName === 'a') {
+					const label = this.formatText(node.textContent || '');
+					const safeLabel = !label || FULL_LINK_PATTERN.test(label) ? 'jump' : label;
+					const href = normalizeLinkUrl(node.getAttribute('href') || '');
+
+					if (!href) {
+						return escapeTelegramHtml(safeLabel);
+					}
+
+					return `<a href="${escapeTelegramAttribute(href)}">${escapeTelegramHtml(safeLabel)}</a>`;
+				}
+
+				const childHtml = Array.from(node.childNodes || [])
+					.map(child => renderNode(child))
+					.join('');
+
+				if (tagName === 'li') {
+					return `\n- ${formatTelegramHtml(childHtml)}\n`;
+				}
+
+				if (BLOCK_TAGS.has(tagName)) {
+					return `\n${formatTelegramHtml(childHtml)}\n`;
+				}
+
+				return childHtml;
+			};
+
+			return formatTelegramHtml(Array.from(document.body.childNodes || [])
+				.map(node => renderNode(node))
+				.join(''));
+		} catch (e) {
+			console.error(e)
+			return ''
+		}
 	},
 
 	htmlToText(content) {

--- a/mail-worker/src/utils/email-utils.js
+++ b/mail-worker/src/utils/email-utils.js
@@ -94,6 +94,47 @@ function formatTelegramHtml(html = '') {
 		.trim();
 }
 
+function renderTelegramLink(label, href) {
+	return `<a href="${escapeTelegramAttribute(href)}">${escapeTelegramHtml(label)}</a>`;
+}
+
+function renderPlainTextUrls(text = '') {
+	let result = '';
+	let lastIndex = 0;
+
+	for (const match of text.matchAll(URL_PATTERN)) {
+		const fullMatch = match[0];
+		const matchIndex = match.index;
+		const { url, trailing } = splitTrailingPunctuation(fullMatch);
+		const href = normalizeLinkUrl(url);
+
+		result += escapeTelegramHtml(text.slice(lastIndex, matchIndex));
+		result += href
+			? `${renderTelegramLink('jump', href)}${escapeTelegramHtml(trailing)}`
+			: escapeTelegramHtml(fullMatch);
+		lastIndex = matchIndex + fullMatch.length;
+	}
+
+	result += escapeTelegramHtml(text.slice(lastIndex));
+	return result;
+}
+
+function renderTextLineWithLinks(line = '') {
+	const referenceMatch = line.match(/^(.*?)\s*\(\s*((?:https?:\/\/|www\.)[^\s()]+)\s*\)\s*$/i);
+
+	if (referenceMatch) {
+		const label = referenceMatch[1].trim();
+		const href = normalizeLinkUrl(referenceMatch[2]);
+
+		if (label && href) {
+			const safeLabel = FULL_LINK_PATTERN.test(label) ? 'jump' : label;
+			return renderTelegramLink(safeLabel, href);
+		}
+	}
+
+	return renderPlainTextUrls(line);
+}
+
 const emailUtils = {
 
 	getDomain(email) {
@@ -140,24 +181,12 @@ const emailUtils = {
 			return '';
 		}
 
-		let result = '';
-		let lastIndex = 0;
-
-		for (const match of formattedText.matchAll(URL_PATTERN)) {
-			const fullMatch = match[0];
-			const matchIndex = match.index;
-			const { url, trailing } = splitTrailingPunctuation(fullMatch);
-			const href = normalizeLinkUrl(url);
-
-			result += escapeTelegramHtml(formattedText.slice(lastIndex, matchIndex));
-			result += href
-				? `<a href="${escapeTelegramAttribute(href)}">jump</a>${escapeTelegramHtml(trailing)}`
-				: escapeTelegramHtml(fullMatch);
-			lastIndex = matchIndex + fullMatch.length;
-		}
-
-		result += escapeTelegramHtml(formattedText.slice(lastIndex));
-		return formatTelegramHtml(result);
+		return formattedText
+			.split('\n')
+			.map(line => renderTextLineWithLinks(line))
+			.join('\n')
+			.replace(/\n{3,}/g, '\n')
+			.trim();
 	},
 
 	htmlToTelegramHtmlLinks(content) {
@@ -198,7 +227,7 @@ const emailUtils = {
 						return escapeTelegramHtml(safeLabel);
 					}
 
-					return `<a href="${escapeTelegramAttribute(href)}">${escapeTelegramHtml(safeLabel)}</a>`;
+					return renderTelegramLink(safeLabel, href);
 				}
 
 				const childHtml = Array.from(node.childNodes || [])


### PR DESCRIPTION
TG机器人转发的邮件中，链接会完整显示出来，导致邮件很长。
添加了可选的原始链接显示选项，位于Telegram机器人的配置选项下：
<img width="500" alt="image" src="https://github.com/user-attachments/assets/7f2d99f6-c053-4e38-8000-a73f3207f13f" />

对比效果如下：

---

隐藏链接：

<img width="500" alt="image" src="https://github.com/user-attachments/assets/abcc69c8-d109-402b-a70c-1146818030c6" />

---
未隐藏链接：

<img width="500" alt="image" src="https://github.com/user-attachments/assets/5a8923dc-3c56-41e8-8039-28659bfd25bd" />

