### PR TITLE
fix: null check logic, silenced flag inversion, sequential query perf

### DIFF
--- a/mail-worker/src/service/email-service.js
+++ b/mail-worker/src/service/email-service.js
@@ -857,9 +857,9 @@ const emailService = {
 			query.orderBy(desc(email.emailId));
 		}
 
-		const listQuery = await query.limit(size).all();
-		const totalQuery = await queryCount.get();
-		const latestEmailQuery = await orm(c).select().from(email)
+		const listQuery = query.limit(size).all();
+		const totalQuery = queryCount.get();
+		const latestEmailQuery = orm(c).select().from(email)
 			.where(and(
 				eq(email.type, emailConst.type.RECEIVE),
 				ne(email.status, emailConst.status.SAVING)

--- a/mail-worker/src/service/oauth-service.js
+++ b/mail-worker/src/service/oauth-service.js
@@ -70,7 +70,7 @@ const oauthService = {
 
 		userInfo.oauthUserId = String(userInfo.id);
 		userInfo.active = userInfo.active ? 0 : 1;
-		userInfo.silenced = userInfo.active ? 0 : 1;
+		userInfo.silenced = userInfo.silenced ? 0 : 1;
 		userInfo.trustLevel = userInfo.trust_level;
 		userInfo.avatar = userInfo.avatar_url;
 

--- a/mail-worker/src/service/role-service.js
+++ b/mail-worker/src/service/role-service.js
@@ -177,7 +177,7 @@ const roleService = {
 
 	selectByUserIds(c, userIds) {
 
-		if (!userIds && userIds.length === 0) {
+		if (!userIds || userIds.length === 0) {
 			return [];
 		}
 


### PR DESCRIPTION
Three bugs I found:

- \`role-service.js\` had \`if (!userIds && userIds.length === 0)\` — when \`userIds\` is null, accessing \`.length\` throws a TypeError. Changed \`&&\` to \`||\` so it returns early properly.

- \`oauth-service.js\` was setting \`userInfo.silenced = userInfo.active ? 0 : 1\` but at that point \`active\` was already inverted on the line above, so \`silenced\` was being derived from the wrong value. Changed to \`userInfo.silenced\` to use the original field.

- \`email-service.js\` was \`await\`ing three queries individually and then passing the resolved values to \`Promise.all\` — they ran sequentially when they could run in parallel. Removed the individual \`await\`s so \`Promise.all\` actually parallelizes them.